### PR TITLE
Remove the "v = new TreeSet<String>(v);" line

### DIFF
--- a/src/com/google/enterprise/adaptor/Metadata.java
+++ b/src/com/google/enterprise/adaptor/Metadata.java
@@ -84,7 +84,6 @@ public class Metadata implements Iterable<Entry<String, String>> {
     if (v.isEmpty()) {
       mappings.remove(k);
     } else {
-      v = new TreeSet<String>(v);
       mappings.put(k, v);
     }
   }


### PR DESCRIPTION
Remove the "v = new TreeSet<String>(v);" line to keep the order of the set.
This change solves issue #2
