### PR TITLE
Add server.hostsSkipCertCheck config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cacerts.jks
 keys.jks
 adaptor.crt
 gsa.crt
+*.class
 
 # IntelliJ files
 workspace/

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -250,6 +250,7 @@ public class Config {
     addKey("server.dashboardPort", "5679");
     addKey("server.docIdPath", "/doc/");
     addKey("server.fullAccessHosts", "");
+    addKey("server.skipCertCheckHosts", "");
     addKey("server.heartbeatPath", "/heartbeat/");
     addKey("server.secure", "false");
     addKey("server.httpBasic.username", "");
@@ -425,9 +426,10 @@ public class Config {
    * authentication checks. The GSA's hostname is implicitly in this list.
    *
    * <p>When in secure mode, clients are requested to provide a client
-   * certificate. If the provided client certificate is valid and the Common
-   * Name (CN) of the Subject is in this list (case-insensitively), then it is
-   * given access.
+   * certificate or be in server.skipCertCheckHosts. If the provided client certificate
+   * is valid and the Common Name (CN) of the Subject is in this list
+   * (case-insensitively), then it is given access. Otherwise, If client IP is in
+   * server.skipCertCheckHosts), then it is given access.
    *
    * <p>In non-secure mode, the hostnames in this list are resolved to IPs at
    * startup and when a request is made from one of those IPs the client is
@@ -435,6 +437,24 @@ public class Config {
    */
   String[] getServerFullAccessHosts() {
     return getValue("server.fullAccessHosts").split(",");
+  }
+
+  /**
+   * Comma-separated list of IPs or hostnames/IPs that can skip
+   * certificate checks.
+   *
+   * <p>When in secure mode, clients are requested to provide either (a trusted
+   * client certificate, OR to be in server.skipCertCheckHosts list) AND (
+   * 1. be in server.fullAccessHosts OR
+   * 2. requested document is public OR
+   * 3. User agent is authenticated shtrough SAML)
+   *
+   * Only for these conditions, web browser can get document content from connector
+   *
+   * <p>In non-secure mode, this option is not used at all.
+   */
+  String[] getServerSkipCertCheckHosts() {
+    return getValue("server.skipCertCheckHosts").split(",");
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -162,7 +162,6 @@ class DocumentHandler implements HttpHandler {
   }
 
   private void initSkipCertAddresses(String[] skipCertCheckHosts) {
-
     for (String hostname : skipCertCheckHosts) {
       try {
         if(hostname.indexOf("/") > 0) {
@@ -418,7 +417,6 @@ class DocumentHandler implements HttpHandler {
     }
 
     InetAddress addr = ex.getRemoteAddress().getAddress();
-
     if (requestIsFromFullyTrustedClient(ex) && addressIsInFullAccess(addr)) {
       // this will end up with return true;
       // only for case, when documents are public or request is from fullAccessAddresses
@@ -1118,11 +1116,10 @@ class DocumentHandler implements HttpHandler {
         acl = aclTransform.transform(acl);
       }
 
-      // client cert is trusted and client host is in fullAccessHosts
+      // client is trusted to receive GSA headers
       if (!considerSkippingTransforms(ex) || alwaysGiveAcl) {
         // Always specify metadata and ACLs, even when empty, to replace
         // previous values.
-
         ex.getResponseHeaders().add("X-Gsa-External-Metadata",
              formMetadataHeader(metadata));
         if (sendDocControls) {

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -164,7 +164,7 @@ class DocumentHandler implements HttpHandler {
   private void initSkipCertAddresses(String[] skipCertCheckHosts) {
     for (String hostname : skipCertCheckHosts) {
       try {
-        if(hostname.indexOf("/") > 0) {
+        if (hostname.indexOf("/") > 0) {
           int index = hostname.indexOf("/");
           String addressPart = hostname.substring(0, index);
           int maskLength = Integer.parseInt(hostname.substring(index + 1));
@@ -173,7 +173,7 @@ class DocumentHandler implements HttpHandler {
         } else {
           InetAddress[] ips = InetAddress.getAllByName(hostname);
           skipCertAddresses.addAll(Arrays.asList(ips));
-          log.log(Level.INFO, "skipCertCheckHosts IP added: {0}", ips);
+          log.log(Level.FINE, "skipCertCheckHosts IP added: {0}", ips);
         }
       } catch (UnknownHostException ex) {
         log.log(Level.WARNING, "Could not resolve hostname. Not adding it to "
@@ -220,19 +220,19 @@ class DocumentHandler implements HttpHandler {
 
   private boolean addressIsInFullAccess(InetAddress addr) {
     boolean trust;
-	trust = fullAccessAddresses.contains(addr);
-	// Only go through the ranges of addresses if we haven't already found
-	// our address in the list of uniquely-identified trusted hosts.  If any
-	// range contains our address, we can stop searching.
-	if (!trust) {
-	  for (CIDRAddress address : fullAccessAddressRanges) {
-	    if (address.isInRange(addr)) {
-	  	trust = true;
-		 break;
-	    }
-	  }
-	}
-	return trust;
+    trust = fullAccessAddresses.contains(addr);
+    // Only go through the ranges of addresses if we haven't already found
+    // our address in the list of uniquely-identified trusted hosts.  If any
+    // range contains our address, we can stop searching.
+    if (!trust) {
+      for (CIDRAddress address : fullAccessAddressRanges) {
+        if (address.isInRange(addr)) {
+          trust = true;
+          break;
+        }
+      }
+    }
+    return trust;
   }
 
   private boolean addressIsInSkipCertAddresses(InetAddress addr) {
@@ -244,8 +244,8 @@ class DocumentHandler implements HttpHandler {
     if (!trust) {
       for (CIDRAddress address : skipCertAddressRanges) {
         if (address.isInRange(addr)) {
-        trust = true;
-         break;
+          trust = true;
+          break;
         }
       }
     }
@@ -293,20 +293,16 @@ class DocumentHandler implements HttpHandler {
       commonName = commonName.toLowerCase(Locale.ENGLISH);
       trust = fullAccessCommonNames.contains(commonName);
       if (trust) {
-        log.log(Level.FINE, "Client is trusted in secure mode: {0}",
-                commonName);
+        log.log(Level.FINE, "Client is trusted in secure mode: {0}", commonName);
       } else {
-        log.log(Level.FINE, "Client is not trusted in secure mode: {0}",
-                commonName);
+        log.log(Level.FINE, "Client is not trusted in secure mode: {0}", commonName);
       }
       InetAddress addr = ex.getRemoteAddress().getAddress();
       trust = trust || addressIsInSkipCertAddresses(addr);
       if (addressIsInSkipCertAddresses(addr)) {
-        log.log(Level.FINE, "IP is trusted in secure mode: {0}",
-            addr);
+        log.log(Level.FINE, "IP is trusted in secure mode: {0}", addr);
       } else {
-        log.log(Level.FINE, "IP is not trusted in secure mode: {0}",
-            addr);
+        log.log(Level.FINE, "IP is not trusted in secure mode: {0}", addr);
       }
     } else {
       InetAddress addr = ex.getRemoteAddress().getAddress();

--- a/src/com/google/enterprise/adaptor/GsaCommunicationHandler.java
+++ b/src/com/google/enterprise/adaptor/GsaCommunicationHandler.java
@@ -318,6 +318,7 @@ public final class GsaCommunicationHandler {
         docIdCodec, docIdCodec, journal, adaptor, adaptorContext.authzAuthority,
         config.getGsaHostname(),
         config.getServerFullAccessHosts(),
+        config.getServerSkipCertCheckHosts(),
         samlServiceProvider, createMetadataTransformPipeline(),
         aclTransform, createContentTransformFactory(),
         config.isServerToUseCompression(), watchdog,

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -34,6 +34,8 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.DateFormat;
@@ -266,6 +268,13 @@ public class DocumentHandlerTest {
     DocumentHandler handler = createDefaultHandlerForAdaptor(
         new PrivateMockAdaptor());
     MockHttpExchange httpEx = ex;
+    // createDefaultHandlerForAdaptor has GSAHost set to localhost.
+    // localhost is also used as trusted CN. We adjusting IP address to localhost
+    httpEx.setRemoteAddress(new InetSocketAddress(
+        InetAddress.getByAddress("localhost",
+          new byte[] {127, 0, 0, 1}),
+        65000));
+
     MockHttpsExchange ex = new MockHttpsExchange(httpEx, new MockSslSession(
         new X500Principal("CN=localhost, OU=Unknown, O=Unknown, C=Unknown")));
     handler.handle(ex);
@@ -2481,6 +2490,517 @@ public class DocumentHandlerTest {
                  + "%2A%28%29%5B%5D%7B%7D%C3%AB%01", encoded);
   }
 
+  // tests for hostsSkipCertCheck
+  // server.fullAccessHosts=192.0.2.0
+  // server.skipCertCheckHosts=192.0.2.0
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhost
+  // result: 403, no headers, skipTransforms=true
+  @Test
+  public void testSkipCertCheckGoodCNBadIP() throws Exception {
+
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhost, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 403 - adaptor trusts to CN=localhost, but requestor ip is unknown
+    assertEquals(403, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  // server.fullAccessHosts=192.0.2.0
+  // server.skipCertCheckHosts=192.0.2.0
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // result: 403, no headers, skipTransforms=true
+  @Test
+  public void testSkipCertCheckBadCNBadIP() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 403 - adaptor doesn't trust to CN=badlocalhost
+    assertEquals(403, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  // server.fullAccessHosts=NOT_OUR_IP_ADDRESS
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // result: 403, no headers
+  @Test
+  public void testSkipCertCheckGoodSkipCertHosts() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {"127.0.0.3"})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 403 - even SkipCertHosts contains requestor IP
+    // this is not enough to return document content
+    assertEquals(403, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  // server.fullAccessHosts=127.0.0.3
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // result: 200, headers are returned
+
+  @Test
+  public void testSkipCertCheckGoodSkipCertHostGoodFullAccessHosts() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {"127.0.0.3"})
+        .setSkipCertHosts(new String[] {"127.0.0.3"})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertFalse(handler.considerSkippingTransforms(httpsEx));
+    // response code 200 - adaptor doesn't trusts to CN=localhostbad
+    // but setSkipCertHosts contains requestor IP
+    assertEquals(200, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata provided. transformation applied
+    assertEquals(Arrays.asList("testing%20key=TESTING%20VALUE", ""),
+        ex.getResponseHeaders().get("X-Gsa-External-Metadata"));
+
+  }
+
+  // server.fullAccessHosts=127.0.0.3
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // result: 200, headers are returned
+
+  @Test
+  public void testSkipCertCheckGoodSkipCertHostGoodFullAccessHostsNetwork() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {"127.0.0.0/8"})
+        .setSkipCertHosts(new String[] {"127.0.0.3/8"})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertFalse(handler.considerSkippingTransforms(httpsEx));
+    // response code 200 - adaptor doesn't trusts to CN=localhostbad
+    // but setSkipCertHosts contains requestor IP
+    assertEquals(200, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata provided. transformation applied
+    assertEquals(Arrays.asList("testing%20key=TESTING%20VALUE", ""),
+        ex.getResponseHeaders().get("X-Gsa-External-Metadata"));
+
+  }
+
+  // server.fullAccessHosts=127.0.0.3
+  // server.skipCertCheckHosts=NOT_OUR_IP_ADDRESS
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhost
+  // result: 200, headers are returned
+
+  @Test
+  public void testSkipCertCheckGoodCNGoodFullAccessHosts() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhost, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {"127.0.0.3"})
+        .setSkipCertHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertFalse(handler.considerSkippingTransforms(httpsEx));
+    // response code 200 - adaptor doesn't trusts to CN=localhostbad
+    // but setSkipCertHosts contains requestor IP
+    assertEquals(200, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata provided. transformation applied
+    assertEquals(Arrays.asList("testing%20key=TESTING%20VALUE", ""),
+        ex.getResponseHeaders().get("X-Gsa-External-Metadata"));
+
+  }
+  // server.fullAccessHosts=127.0.0.3
+  // server.skipCertCheckHosts=NOT_OUR_IP_ADDRESS
+  // adaptor trusts to CN=localhost
+  // requestor ip=127.0.0.3
+  // requestor CN=localhostbad
+  // result: 403, no headers
+  @Test
+  public void testSkipCertCheckGoodFullAccessHostsOnly() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setFullAccessHosts(new String[] {"127.0.0.3"})
+        .setSkipCertHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 403 - adaptor does not trusts to CN=localhostbad
+    // and setSkipCertHosts doesn't contains requestor IP
+    assertEquals(403, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  // server.fullAccessHosts=NOT_OUR_IP_ADDRESS
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // result: 200, no headers
+  @Test
+  public void testSkipCertCheckGoodSkipCertHostsPublicDoc() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setMarkDocsPublic(true)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {"127.0.0.3"})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 200 - adaptor trusts to skipCertHosts, doc is public
+    assertEquals(200, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  // server.fullAccessHosts=NOT_OUR_IP_ADDRESS
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip = 127.0.0.3
+  // requestor CN=localhostbad
+  // saml returns PERMIT for any document
+  // result: 200, no headers
+  @Test
+  public void testSkipCertCheckGoodSkipCertHostsUserHasAccess() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+    MockSamlServiceProvider samlServiceProvider = new MockSamlServiceProvider();
+    samlServiceProvider.setUserIdentity(new AuthnIdentityImpl
+        .Builder(new UserPrincipal("test")).build());
+    
+    UserPrivateMockAdaptor adaptor = new UserPrivateMockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.addMetadata(key, "testing value");
+        super.getDocContent(request, response);
+      }
+    };
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setSamlServiceProvider(samlServiceProvider)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {"127.0.0.3"})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 200 - adaptor trusts to skipCertHosts
+    assertEquals(200, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
+  
+  // server.fullAccessHosts=NOT_OUR_IP_ADDRESS
+  // server.skipCertCheckHosts=127.0.0.3
+  // adaptor trusts to CN=localhost
+  // requestor ip=127.0.0.3
+  // requestor CN=localhostbad
+  // saml returns DENY for any document
+  // result: 200, no headers
+  @Test
+  public void testSkipCertCheckGoodSkipCertHostsUserHasDeny() throws Exception {
+    MockHttpsExchange httpsEx = new MockHttpsExchange(ex, new MockSslSession(
+        new X500Principal("CN=localhostbad, OU=Unknown, O=Unknown, C=Unknown")));
+
+    final String key = "testing key";
+    List<MetadataTransform> transforms
+        = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        metadata.set(key, metadata.getOneValue(key).toUpperCase());
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+
+    MockSamlServiceProvider samlServiceProvider = new MockSamlServiceProvider();
+    samlServiceProvider.setUserIdentity(new AuthnIdentityImpl
+        .Builder(new UserPrincipal("test")).build());    
+
+    PrivateMockAdaptor adaptor = new PrivateMockAdaptor();
+
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(adaptor)
+        .setAuthzAuthority(adaptor)
+        .setSamlServiceProvider(samlServiceProvider)
+        .setFullAccessHosts(new String[] {NOT_OUR_IP_ADDRESS})
+        .setSkipCertHosts(new String[] {"127.0.0.3"})
+        .setMetadataTransform(transform)
+        .build();
+
+    handler.handle(httpsEx);
+
+    assertTrue(handler.considerSkippingTransforms(httpsEx));
+    // response code 403 - user is not trusted
+    assertEquals(403, httpsEx.getResponseCode());
+    // X-Gsa-External-Metadata not provided
+    assertNull(httpsEx.getResponseHeaders().get("X-Gsa-External-Metadata"));
+  }
+
   private static class UserPrivateMockAdaptor extends MockAdaptor {
       @Override
       public Map<DocId, AuthzStatus> isUserAuthorized(AuthnIdentity identity,
@@ -2548,6 +3068,7 @@ public class DocumentHandlerTest {
     private AuthzAuthority authzAuthority;
     private String gsaHostname;
     private String[] fullAccessHosts = new String[0];
+    private String[] skipCertHosts = new String[0];
     private SamlServiceProvider samlServiceProvider;
     private MetadataTransformPipeline transform;
     private ContentTransformFactory contentTransformPipeline;
@@ -2599,6 +3120,11 @@ public class DocumentHandlerTest {
 
     public DocumentHandlerBuilder setFullAccessHosts(String[] fullAccessHosts) {
       this.fullAccessHosts = fullAccessHosts;
+      return this;
+    }
+
+    public DocumentHandlerBuilder setSkipCertHosts(String[] skipCertHosts) {
+      this.skipCertHosts = skipCertHosts;
       return this;
     }
 
@@ -2681,7 +3207,7 @@ public class DocumentHandlerTest {
 
     public DocumentHandler build() {
       return new DocumentHandler(docIdDecoder, docIdEncoder, journal, adaptor,
-          authzAuthority, gsaHostname, fullAccessHosts, samlServiceProvider,
+          authzAuthority, gsaHostname, fullAccessHosts, skipCertHosts, samlServiceProvider,
           transform, aclTransform, contentTransformPipeline, useCompression,
           watchdog, pusher, sendDocControls, markDocsPublic,
           headerTimeoutMillis, contentTimeoutMillis, scoring,

--- a/test/com/google/enterprise/adaptor/HeartbeatHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/HeartbeatHandlerTest.java
@@ -434,7 +434,7 @@ public class HeartbeatHandlerTest {
     Adaptor adaptor = new UserPrivateMockAdaptor();
     DocumentHandler docHandler = new DocumentHandler(docIdCodec, docIdCodec,
         new Journal(new MockTimeProvider()), adaptor, (AuthzAuthority) adaptor,
-        "localhost", new String[0], samlServiceProvider,
+        "localhost", new String[0], new String[0], samlServiceProvider,
         null /* metadataTransformPipeline */,
         new AclTransform(Arrays.<AclTransform.Rule>asList()),
         null /* contentTransformFactory */, false /* useCompression */,
@@ -563,6 +563,7 @@ public class HeartbeatHandlerTest {
     private AuthzAuthority authzAuthority;
     private String gsaHostname;
     private String[] fullAccessHosts = new String[0];
+    private String[] skipCertHosts = new String[0];
     private SamlServiceProvider samlServiceProvider;
     private MetadataTransformPipeline transform;
     private ContentTransformFactory contentTransformPipeline;
@@ -696,7 +697,7 @@ public class HeartbeatHandlerTest {
 
     public DocumentHandler build() {
       return new DocumentHandler(docIdDecoder, docIdEncoder, journal, adaptor,
-          authzAuthority, gsaHostname, fullAccessHosts, samlServiceProvider,
+          authzAuthority, gsaHostname, fullAccessHosts, skipCertHosts, samlServiceProvider,
           transform, aclTransform, contentTransformPipeline, useCompression,
           watchdog, pusher, sendDocControls, markDocsPublic,
           headerTimeoutMillis, contentTimeoutMillis, scoring,


### PR DESCRIPTION
Brief description:
Customer has configured connector v4 with server.secure=true (GSA is trusted, all keys and certs are configured). And he wants to see what is returned by the connector during crawl.
Having this option, customer can access connector content over https, without need to add its certificate to connector keystore. 
Using this flag causes risks (IP is spoofable) and is for temporary debugging only.

logic on pseudocode:
if (https is used **AND** (client cert is trusted **OR** client is allowed to skip cert check)) {
   If (full access host) { 
      ... allow any document and provide GSA headers
   } else if (document is public) { // case 3
     ... allow document content, but no GSA headers
   } else if (UA has authenticated user **AND** that user is authorized for doc) {
     ... allow document content, but no GSA headers
  } else {
     .... either not authenticated or not authorized so: no content, and no headers
  }
} else {
// this is http access, 
// logic was not changed
}
