### PR TITLE
add server.hostsSkipCertCheck option to adaptor config parser.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cacerts.jks
 keys.jks
 adaptor.crt
 gsa.crt
+*.class
 
 # IntelliJ files
 workspace/

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -254,6 +254,7 @@ public class Config {
     addKey("server.dashboardPort", "5679");
     addKey("server.docIdPath", "/doc/");
     addKey("server.fullAccessHosts", "");
+    addKey("server.skipCertCheckHosts", "");
     addKey("server.heartbeatPath", "/heartbeat/");
     addKey("server.secure", "false");
     addKey("server.httpBasic.username", "");
@@ -439,6 +440,26 @@ public class Config {
    */
   String[] getServerFullAccessHosts() {
     return getValue("server.fullAccessHosts").split(",");
+  }
+
+  /**
+   * DANGER, use for debugging only.
+   * Comma-separated list of IPs or hostnames that can skip
+   * certificate checks. Used only for server.secure=true mode
+   *
+   * <p>When in secure mode, clients are requested to provide either (a trusted
+   * client certificate, OR to be in server.skipCertCheckHosts list) AND (
+   * 1. be in server.fullAccessHosts OR
+   * 2. requested document is public OR
+   * 3. User agent is authenticated trough SAML)
+   *
+   * Only for these conditions, web browser can get document content from 
+   * connector
+   *
+   * <p>In non-secure mode, this option is not used at all.
+   */
+  String[] getServerSkipCertCheckHosts() {
+    return getValue("server.skipCertCheckHosts").split(",");
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -451,7 +451,7 @@ public class Config {
    * client certificate, OR to be in server.skipCertCheckHosts list) AND (
    * 1. be in server.fullAccessHosts OR
    * 2. requested document is public OR
-   * 3. User agent is authenticated trough SAML)
+   * 3. User agent is authenticated and authorized for document)
    *
    * Only for these conditions, web browser can get document content from 
    * connector

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -160,7 +160,7 @@ class DocumentHandler implements HttpHandler {
       try {
         if (hostname.indexOf("/") > 0) {
           log.log(Level.WARNING, "skipCertCheckHosts doesn't support networks:"
-                 + hostname, ex); 
+                 + hostname); 
         } else {
           InetAddress[] ips = InetAddress.getAllByName(hostname);
           skipCertAddresses.addAll(Arrays.asList(ips));

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -159,8 +159,8 @@ class DocumentHandler implements HttpHandler {
     for (String hostname : skipCertCheckHosts) {
       try {
         if (hostname.indexOf("/") > 0) {
-          log.log(Level.WARNING, "skipCertCheckHosts doesn't support networks:"
-                 + hostname); 
+          log.log(Level.WARNING, "skipCertCheckHosts doesn't support "
+              + "networks: " + hostname); 
         } else {
           InetAddress[] ips = InetAddress.getAllByName(hostname);
           skipCertAddresses.addAll(Arrays.asList(ips));

--- a/src/com/google/enterprise/adaptor/GsaCommunicationHandler.java
+++ b/src/com/google/enterprise/adaptor/GsaCommunicationHandler.java
@@ -318,6 +318,7 @@ public final class GsaCommunicationHandler {
         docIdCodec, docIdCodec, journal, adaptor, adaptorContext.authzAuthority,
         config.getGsaHostname(),
         config.getServerFullAccessHosts(),
+        config.getServerSkipCertCheckHosts(),
         samlServiceProvider, createMetadataTransformPipeline(),
         aclTransform, createContentTransformFactory(),
         config.isServerToUseCompression(), watchdog,

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -2548,6 +2548,7 @@ public class DocumentHandlerTest {
     private AuthzAuthority authzAuthority;
     private String gsaHostname;
     private String[] fullAccessHosts = new String[0];
+    private String[] skipCertHosts = new String[0];
     private SamlServiceProvider samlServiceProvider;
     private MetadataTransformPipeline transform;
     private ContentTransformFactory contentTransformPipeline;
@@ -2599,6 +2600,11 @@ public class DocumentHandlerTest {
 
     public DocumentHandlerBuilder setFullAccessHosts(String[] fullAccessHosts) {
       this.fullAccessHosts = fullAccessHosts;
+      return this;
+    }
+
+    public DocumentHandlerBuilder setSkipCertHosts(String[] skipCertHosts) {
+      this.skipCertHosts = skipCertHosts;
       return this;
     }
 
@@ -2681,7 +2687,7 @@ public class DocumentHandlerTest {
 
     public DocumentHandler build() {
       return new DocumentHandler(docIdDecoder, docIdEncoder, journal, adaptor,
-          authzAuthority, gsaHostname, fullAccessHosts, samlServiceProvider,
+          authzAuthority, gsaHostname, fullAccessHosts, skipCertHosts, samlServiceProvider,
           transform, aclTransform, contentTransformPipeline, useCompression,
           watchdog, pusher, sendDocControls, markDocsPublic,
           headerTimeoutMillis, contentTimeoutMillis, scoring,

--- a/test/com/google/enterprise/adaptor/HeartbeatHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/HeartbeatHandlerTest.java
@@ -434,7 +434,7 @@ public class HeartbeatHandlerTest {
     Adaptor adaptor = new UserPrivateMockAdaptor();
     DocumentHandler docHandler = new DocumentHandler(docIdCodec, docIdCodec,
         new Journal(new MockTimeProvider()), adaptor, (AuthzAuthority) adaptor,
-        "localhost", new String[0], samlServiceProvider,
+        "localhost", new String[0], new String[0], samlServiceProvider,
         null /* metadataTransformPipeline */,
         new AclTransform(Arrays.<AclTransform.Rule>asList()),
         null /* contentTransformFactory */, false /* useCompression */,
@@ -563,6 +563,7 @@ public class HeartbeatHandlerTest {
     private AuthzAuthority authzAuthority;
     private String gsaHostname;
     private String[] fullAccessHosts = new String[0];
+    private String[] skipCertHosts = new String[0];
     private SamlServiceProvider samlServiceProvider;
     private MetadataTransformPipeline transform;
     private ContentTransformFactory contentTransformPipeline;
@@ -696,7 +697,7 @@ public class HeartbeatHandlerTest {
 
     public DocumentHandler build() {
       return new DocumentHandler(docIdDecoder, docIdEncoder, journal, adaptor,
-          authzAuthority, gsaHostname, fullAccessHosts, samlServiceProvider,
+          authzAuthority, gsaHostname, fullAccessHosts, skipCertHosts, samlServiceProvider,
           transform, aclTransform, contentTransformPipeline, useCompression,
           watchdog, pusher, sendDocControls, markDocsPublic,
           headerTimeoutMillis, contentTimeoutMillis, scoring,


### PR DESCRIPTION
this change introduces new parameter server.hostsSkipCertCheck to connector. 
parameter is parsed, and passed to DocumentHandler.java .
No logic is implemented for this parameter yet.
