### PR TITLE
Fix b/33924233 Use noIndex instead of notFound when skipping docs

### DIFF
--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -870,15 +870,17 @@ class DocumentHandler implements HttpHandler {
           // Send no body and no metadata, other than Robots noindex.
           ex.getResponseHeaders().add("X-Robots-Tag", "noindex");
           int rc = HttpURLConnection.HTTP_OK;
-          HttpExchanges.startResponse(ex, rc, "text/plain", /*hasBody=*/ false);
-          os = new SinkOutputStream(new CloseNotifyOutputStream(
+          HttpExchanges.startResponse(ex, rc, "text/plain", /*hasBody=*/ true);
+          countingOs = new CountingOutputStream(new CloseNotifyOutputStream(
               ex.getResponseBody()));
+          os = new SinkOutputStream(countingOs);
         } else if (state == State.SEND_BODY_TRANSFORMED_TO_HEAD) {
           log.log(Level.INFO, "changed SEND_BODY to HEAD {0}",
               docId.getUniqueId());
           startSending(true);  // Lie about content. Will be 0bytes chunked.
-          os = new SinkOutputStream(new CloseNotifyOutputStream(
+          countingOs = new CountingOutputStream(new CloseNotifyOutputStream(
               ex.getResponseBody()));
+          os = new SinkOutputStream(countingOs);
         } else {
           throw new IllegalStateException("unexpected state: " + state);
         }

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -786,7 +786,7 @@ class DocumentHandler implements HttpHandler {
             (requestIsFromFullyTrustedClient(ex)
                 ? HttpURLConnection.HTTP_NO_CONTENT
                 : HttpURLConnection.HTTP_NOT_MODIFIED),
-            "text/plain", (byte[]) null);
+            "text/plain", new byte[0]);
       } else {
         throw new IllegalStateException("unexpected state: " + state);
       }

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -519,7 +519,7 @@ public class DocumentHandlerTest {
     assertEquals(200, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
     assertEquals(null,
-        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -518,7 +518,8 @@ public class DocumentHandlerTest {
     handler.handle(ex);
     assertEquals(200, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertNull(ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertEquals(null,
+        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 
@@ -553,7 +554,8 @@ public class DocumentHandlerTest {
     assertEquals(200, headEx.getResponseCode());
     assertEquals("noindex",
         headEx.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertNull(headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertEquals(null,
+        headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     // Response to HEAD request does not have content (it is HEAD)
     assertArrayEquals(new byte[0], headEx.getResponseBytes());
   }
@@ -728,7 +730,8 @@ public class DocumentHandlerTest {
     handler.handle(ex);
     assertEquals(204, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertNull(ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertEquals(null,
+        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -555,7 +555,7 @@ public class DocumentHandlerTest {
     assertEquals("noindex",
         headEx.getResponseHeaders().getFirst("X-Robots-Tag"));
     assertEquals(null,
-        headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+         headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     // Response to HEAD request does not have content (it is HEAD)
     assertArrayEquals(new byte[0], headEx.getResponseBytes());
   }

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -731,7 +731,7 @@ public class DocumentHandlerTest {
     assertEquals(204, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
     assertEquals(null,
-        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -518,9 +518,8 @@ public class DocumentHandlerTest {
     handler.handle(ex);
     assertEquals(200, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertEquals("docid=test%20docId,test%20key=testing%20value",
-        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
-    assertArrayEquals(mockAdaptor.documentBytes, ex.getResponseBytes());
+    assertNull(ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 
   @Test
@@ -554,10 +553,9 @@ public class DocumentHandlerTest {
     assertEquals(200, headEx.getResponseCode());
     assertEquals("noindex",
         headEx.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertEquals("docid=test%20docId,test%20key=testing%20value",
-        headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertNull(headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     // Response to HEAD request does not have content (it is HEAD)
-    assertArrayEquals("".getBytes(), headEx.getResponseBytes());
+    assertArrayEquals(new byte[0], headEx.getResponseBytes());
   }
 
   @Test
@@ -730,8 +728,7 @@ public class DocumentHandlerTest {
     handler.handle(ex);
     assertEquals(204, ex.getResponseCode());
     assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
-    assertEquals("docid=test%20docId,test%20key=testing%20value",
-        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertNull(ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -489,7 +489,7 @@ public class DocumentHandlerTest {
   }
 
   @Test
-  public void testDroppingDocForGetRequest() throws Exception {
+  public void testDoNotIndexForGetRequest() throws Exception {
     List<MetadataTransform> transforms = new LinkedList<MetadataTransform>();
     transforms.add(new MetadataTransform() {
       @Override
@@ -516,14 +516,15 @@ public class DocumentHandlerTest {
         .build();
     mockAdaptor.documentBytes = new byte[] {1, 2, 3};
     handler.handle(ex);
-    assertEquals(404, ex.getResponseCode());
-    assertEquals(null,
-         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
-    assertArrayEquals("Error 404: Not Found".getBytes(), ex.getResponseBytes());
+    assertEquals(200, ex.getResponseCode());
+    assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
+    assertEquals("docid=test%20docId,test%20key=testing%20value",
+        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertArrayEquals(mockAdaptor.documentBytes, ex.getResponseBytes());
   }
 
   @Test
-  public void testDroppingDocForHeadRequest() throws Exception {
+  public void testDoNotIndexForHeadRequest() throws Exception {
     List<MetadataTransform> transforms = new LinkedList<MetadataTransform>();
     transforms.add(new MetadataTransform() {
       @Override
@@ -550,10 +551,12 @@ public class DocumentHandlerTest {
         .build();
     mockAdaptor.documentBytes = new byte[] {1, 2, 3};
     handler.handle(headEx);
-    assertEquals(404, headEx.getResponseCode());
-    assertEquals(null,
-         headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
-    // 404 response to HEAD request does not have content (it is HEAD)
+    assertEquals(200, headEx.getResponseCode());
+    assertEquals("noindex",
+        headEx.getResponseHeaders().getFirst("X-Robots-Tag"));
+    assertEquals("docid=test%20docId,test%20key=testing%20value",
+        headEx.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    // Response to HEAD request does not have content (it is HEAD)
     assertArrayEquals("".getBytes(), headEx.getResponseBytes());
   }
 
@@ -698,7 +701,7 @@ public class DocumentHandlerTest {
   }
 
   @Test
-  public void testDroppingDocAfterNoContent() throws Exception {
+  public void testDoNotIndexAfterNoContent() throws Exception {
     List<MetadataTransform> transforms = new LinkedList<MetadataTransform>();
     transforms.add(new MetadataTransform() {
       @Override
@@ -725,11 +728,11 @@ public class DocumentHandlerTest {
         .build();
     mockAdaptor.documentBytes = new byte[] {1, 2, 3};
     handler.handle(ex);
-    assertEquals(404, ex.getResponseCode());
-    assertEquals(null,
-         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
-    // The 204 that would not have content becomes a 404 with content
-    assertArrayEquals("Error 404: Not Found".getBytes(), ex.getResponseBytes());
+    assertEquals(204, ex.getResponseCode());
+    assertEquals("noindex", ex.getResponseHeaders().getFirst("X-Robots-Tag"));
+    assertEquals("docid=test%20docId,test%20key=testing%20value",
+        ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertArrayEquals(new byte[0], ex.getResponseBytes());
   }
 
   @Test
@@ -761,6 +764,7 @@ public class DocumentHandlerTest {
     mockAdaptor.documentBytes = new byte[] {1, 2, 3};
     handler.handle(ex);
     assertEquals(204, ex.getResponseCode());
+    assertEquals(null, ex.getResponseHeaders().getFirst("X-Robots-Tag"));
     assertEquals("docid=test%20docId,test%20key=TESTING%20VALUE",
         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
     assertArrayEquals(new byte[0], ex.getResponseBytes());


### PR DESCRIPTION
This change has a TransmissionDecision of do-not-index set
the "X-Robots-Tag=noindex" header, then discard metadata,
ACLs, and content; rather than returning a 404 response code.