### PR TITLE
Fix b/32321298 Part2: FilterMimetypes conditionally sets TransmissionDecision

### DIFF
--- a/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
@@ -129,6 +129,7 @@ public class FilterMimetypes implements MetadataTransform {
       ct = ct.substring(0, semicolonIndex);
     }
     ct = ct.trim().toLowerCase();
+    // First look in the cache to see if we have encounted this mimetype before.
     String decision = lookupDecision(ct);
     if (null != decision) {
       if (!decision.equals(TransmissionDecision.AS_IS.toString())) {
@@ -138,6 +139,8 @@ public class FilterMimetypes implements MetadataTransform {
     }
     if (supportedExplicit.contains(ct)) {
       log.log(Level.FINE, ct + "is explicitly supported");
+      // Even though we do not explicitly set the decision, still cache
+      // the result for future encounters of this same mime-type.
       insertDecision(ct, TransmissionDecision.AS_IS.toString());
     } else if (unsupportedExplicit.contains(ct)) {
       log.log(Level.FINE, ct + "is explicitly unsupported");

--- a/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
@@ -132,7 +132,7 @@ public class FilterMimetypes implements MetadataTransform {
     String decision = lookupDecision(ct);
     if (null != decision) {
       if (!decision.equals(TransmissionDecision.AS_IS.toString())) {
-        params.put("Transmission-Decision", decision);
+        params.put(MetadataTransform.KEY_TRANSMISSION_DECISION, decision);
       }
       return;
     }

--- a/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
@@ -137,8 +137,6 @@ public class FilterMimetypes implements MetadataTransform {
     if (supportedExplicit.contains(ct)) {
       log.log(Level.FINE, ct + "is explicitly supported");
       insertDecision(ct, TransmissionDecision.AS_IS.toString());
-      params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,
-          TransmissionDecision.AS_IS.toString());
     } else if (unsupportedExplicit.contains(ct)) {
       log.log(Level.FINE, ct + "is explicitly unsupported");
       insertDecision(ct, TransmissionDecision.DO_NOT_INDEX_CONTENT.toString());
@@ -151,8 +149,6 @@ public class FilterMimetypes implements MetadataTransform {
           TransmissionDecision.DO_NOT_INDEX.toString());
     } else if (matches(supportedGlobs, ct, "supported by glob")) {
       insertDecision(ct, TransmissionDecision.AS_IS.toString());
-      params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,
-          TransmissionDecision.AS_IS.toString());
     } else if (matches(unsupportedGlobs, ct, "unsupported by glob")) {
       insertDecision(ct, TransmissionDecision.DO_NOT_INDEX_CONTENT.toString());
       params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,

--- a/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/FilterMimetypes.java
@@ -131,7 +131,9 @@ public class FilterMimetypes implements MetadataTransform {
     ct = ct.trim().toLowerCase();
     String decision = lookupDecision(ct);
     if (null != decision) {
-      params.put("Transmission-Decision", decision);
+      if (!decision.equals(TransmissionDecision.AS_IS.toString())) {
+        params.put("Transmission-Decision", decision);
+      }
       return;
     }
     if (supportedExplicit.contains(ct)) {

--- a/test/com/google/enterprise/adaptor/prebuilt/FilterMimetypesTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/FilterMimetypesTest.java
@@ -40,7 +40,7 @@ public class FilterMimetypesTest {
     Map<String, String> params = new HashMap<String, String>();
     params.put("Content-Type", "text/rtf");
     transform.transform(new Metadata(), params);
-    assertEquals("as-is", params.get("Transmission-Decision"));
+    assertEquals(null, params.get("Transmission-Decision"));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class FilterMimetypesTest {
     Map<String, String> params = new HashMap<String, String>();
     params.put("Content-Type", "text/richtext  ;  itsy-bitsy-characters");
     transform.transform(new Metadata(), params);
-    assertEquals("as-is", params.get("Transmission-Decision"));
+    assertEquals(null, params.get("Transmission-Decision"));
   }
 
   @Test
@@ -85,7 +85,7 @@ public class FilterMimetypesTest {
     Map<String, String> params = new HashMap<String, String>();
     params.put("Content-Type", "  text/rtf  ;  param-uno   ; paribo");
     transform.transform(new Metadata(), params);
-    assertEquals("as-is", params.get("Transmission-Decision"));
+    assertEquals(null, params.get("Transmission-Decision"));
   }
 
   @Test
@@ -94,7 +94,7 @@ public class FilterMimetypesTest {
     Map<String, String> params = new HashMap<String, String>();
     params.put("Content-Type", "  TeXt/RtF  ;  param-uno   ; paribo");
     transform.transform(new Metadata(), params);
-    assertEquals("as-is", params.get("Transmission-Decision"));
+    assertEquals(null, params.get("Transmission-Decision"));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class FilterMimetypesTest {
     Map<String, String> params = new HashMap<String, String>();
     params.put("Content-Type", "text/that-is-textual");
     transform.transform(new Metadata(), params);
-    assertEquals("as-is", params.get("Transmission-Decision"));
+    assertEquals(null, params.get("Transmission-Decision"));
   }
 
   @Test


### PR DESCRIPTION
This change changes FilterMimetypes to only set the TransmissionDecision
to do-not-index or do-not-index-content when its conditions are met.
Otherwise, the TransmissionDecision remains unchanged.
This allows FilterMimetyps to be used with other TransmissionDecision
filters in the metadata transform pipeline.