### PR TITLE
Fix b/29451090 adding validation and tests for timeout parameters

### DIFF
--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -650,7 +650,7 @@ public class Config {
         return Long.parseLong(secondsAsString) * 1000;
       } catch (NumberFormatException nfe) {
         throw new InvalidConfigurationException("Invalid value for "
-            + property + ". Only a numeric value is accepted.");
+            + property + ". Only a positive integer value is accepted.");
       }
     }
   }

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -643,19 +643,19 @@ public class Config {
     String secondsAsString = getValue(property).trim();
     if ("adaptor.heartbeatTimeoutSecs".equalsIgnoreCase(property) &&
         "".equals(secondsAsString)) {
-      // if heartbeatTimeoutSecs is empty, default value is docHeaderTimeoutSecs value
+      // if heartbeatTimeoutSecs is empty, default value is docHeaderTimeoutSecs
       return getAdaptorDocHeaderTimeoutMillis();
     } else {
       if ("0".equals(secondsAsString) || "".equals(secondsAsString) ||
           secondsAsString.startsWith("-") ) {
-        throw new InvalidConfigurationException("Invalid value for " + property +
-            ". Zero, empty and negative values are not accepted.");
+        throw new InvalidConfigurationException("Invalid value for " + property
+            + ". Zero, empty and negative values are not accepted.");
       } else {
         try {
           return Long.parseLong(secondsAsString) * 1000;
         } catch (NumberFormatException nfe) {
-          throw new InvalidConfigurationException("Invalid value for " + property +
-              ". Only a numeric value is accepted.");
+          throw new InvalidConfigurationException("Invalid value for "
+              + property + ". Only a numeric value is accepted.");
         }
       }
     }

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -639,44 +639,42 @@ public class Config {
     return getValue("adaptor.fullListingSchedule");
   }
 
-  long getAdaptorIncrementalPollPeriodMillis() {
-    return Long.parseLong(getValue("adaptor.incrementalPollPeriodSecs")) * 1000;
+  public long validateTimeout(String property) {
+    String secondsAsString = getValue(property).trim();
+    if ("adaptor.heartbeatTimeoutSecs".equalsIgnoreCase(property) &&
+        "".equals(secondsAsString)) {
+      // if heartbeatTimeoutSecs is empty, default value is docHeaderTimeoutSecs value
+      return getAdaptorDocHeaderTimeoutMillis();
+    } else {
+      if ("0".equals(secondsAsString) || "".equals(secondsAsString) ||
+          secondsAsString.startsWith("-") ) {
+        throw new InvalidConfigurationException("Invalid value for " + property +
+            ". Zero, empty and negative values are not accepted.");
+      } else {
+        try {
+          return Long.parseLong(secondsAsString) * 1000;
+        } catch (NumberFormatException nfe) {
+          throw new InvalidConfigurationException("Invalid value for " + property +
+              ". Only a numeric value is accepted.");
+        }
+      }
+    }
   }
 
-  public long validateTimeout(String property, String defaultValue,
-      boolean allowNeg, boolean allowEmpty) {
-    String secondsAsString = getValue(property).trim();
-    try {
-      if ((null == secondsAsString) || "0".equals(secondsAsString) ||
-          (("".equals(secondsAsString) && !(allowEmpty))) ||
-          (secondsAsString.startsWith("-") && !(allowNeg))) {
-        log.log(Level.WARNING, "Invalid value for " + property
-                + ", it has been set to default " + defaultValue + " seconds.");
-      } else {
-          return Long.parseLong(secondsAsString) * 1000;
-      }
-    } catch (NumberFormatException e) {
-      log.log(Level.WARNING, "Invalid value for " + property
-              + ", it has been set to default " + defaultValue + " seconds.");
-    }
-    // For invalid value, returning default
-    // We do not reach this line if value is valid
-    return Long.parseLong(defaultValue) * 1000;
+  long getAdaptorIncrementalPollPeriodMillis() {
+    return validateTimeout("adaptor.incrementalPollPeriodSecs");
   }
 
   long getAdaptorDocHeaderTimeoutMillis() {
-    return validateTimeout("adaptor.docHeaderTimeoutSecs", "30", false, false);
+    return validateTimeout("adaptor.docHeaderTimeoutSecs");
   }
 
   long getAdaptorDocContentTimeoutMillis() {
-    return validateTimeout("adaptor.docContentTimeoutSecs", "180",
-                           false, false);
+    return validateTimeout("adaptor.docContentTimeoutSecs");
   }
 
   long getAdaptorHeartbeatTimeoutMillis() {
-    return validateTimeout("adaptor.heartbeatTimeoutSecs", Long.toString(
-                           getAdaptorDocHeaderTimeoutMillis() / 1000),
-                           false, false);
+    return validateTimeout("adaptor.heartbeatTimeoutSecs");
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -643,20 +643,40 @@ public class Config {
     return Long.parseLong(getValue("adaptor.incrementalPollPeriodSecs")) * 1000;
   }
 
+  public long validateTimeout(String property, String defaultValue,
+      boolean allowNeg, boolean allowEmpty) {
+    String secondsAsString = getValue(property).trim();
+    try {
+      if ((null == secondsAsString) || "0".equals(secondsAsString) ||
+          (("".equals(secondsAsString) && !(allowEmpty))) ||
+          (secondsAsString.startsWith("-") && !(allowNeg))) {
+        log.log(Level.WARNING, "Invalid value for " + property
+                + ", it has been set to default " + defaultValue + " seconds.");
+      } else {
+          return Long.parseLong(secondsAsString) * 1000;
+      }
+    } catch (NumberFormatException e) {
+      log.log(Level.WARNING, "Invalid value for " + property
+              + ", it has been set to default " + defaultValue + " seconds.");
+    }
+    // For invalid value, returning default
+    // We do not reach this line if value is valid
+    return Long.parseLong(defaultValue) * 1000;
+  }
+
   long getAdaptorDocHeaderTimeoutMillis() {
-    return Long.parseLong(getValue("adaptor.docHeaderTimeoutSecs")) * 1000;
+    return validateTimeout("adaptor.docHeaderTimeoutSecs", "30", false, false);
   }
 
   long getAdaptorDocContentTimeoutMillis() {
-    return Long.parseLong(getValue("adaptor.docContentTimeoutSecs")) * 1000;
+    return validateTimeout("adaptor.docContentTimeoutSecs", "180",
+                           false, false);
   }
 
   long getAdaptorHeartbeatTimeoutMillis() {
-    String secondsAsString = getValue("adaptor.heartbeatTimeoutSecs");
-    if ((null == secondsAsString) || "".equals(secondsAsString.trim())) {
-      secondsAsString = getValue("adaptor.docHeaderTimeoutSecs");
-    }
-    return Long.parseLong(secondsAsString) * 1000;
+    return validateTimeout("adaptor.heartbeatTimeoutSecs", Long.toString(
+                           getAdaptorDocHeaderTimeoutMillis() / 1000),
+                           false, false);
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -641,22 +641,16 @@ public class Config {
 
   public long validateTimeout(String property) {
     String secondsAsString = getValue(property).trim();
-    if ("adaptor.heartbeatTimeoutSecs".equalsIgnoreCase(property) &&
-        "".equals(secondsAsString)) {
-      // if heartbeatTimeoutSecs is empty, default value is docHeaderTimeoutSecs
-      return getAdaptorDocHeaderTimeoutMillis();
+    if ("0".equals(secondsAsString) || "".equals(secondsAsString) ||
+        secondsAsString.startsWith("-") ) {
+      throw new InvalidConfigurationException("Invalid value for " + property
+          + ". Zero, empty and negative values are not accepted.");
     } else {
-      if ("0".equals(secondsAsString) || "".equals(secondsAsString) ||
-          secondsAsString.startsWith("-") ) {
-        throw new InvalidConfigurationException("Invalid value for " + property
-            + ". Zero, empty and negative values are not accepted.");
-      } else {
-        try {
-          return Long.parseLong(secondsAsString) * 1000;
-        } catch (NumberFormatException nfe) {
-          throw new InvalidConfigurationException("Invalid value for "
-              + property + ". Only a numeric value is accepted.");
-        }
+      try {
+        return Long.parseLong(secondsAsString) * 1000;
+      } catch (NumberFormatException nfe) {
+        throw new InvalidConfigurationException("Invalid value for "
+            + property + ". Only a numeric value is accepted.");
       }
     }
   }
@@ -674,7 +668,12 @@ public class Config {
   }
 
   long getAdaptorHeartbeatTimeoutMillis() {
-    return validateTimeout("adaptor.heartbeatTimeoutSecs");
+    if (getValue("adaptor.heartbeatTimeoutSecs").trim().length() == 0) {
+      // if heartbeatTimeoutSecs is empty, default value is docHeaderTimeoutSecs
+      return getAdaptorDocHeaderTimeoutMillis();
+    } else {
+      return validateTimeout("adaptor.heartbeatTimeoutSecs");
+    }
   }
 
   /**

--- a/test/com/google/enterprise/adaptor/ConfigTest.java
+++ b/test/com/google/enterprise/adaptor/ConfigTest.java
@@ -339,7 +339,7 @@ public class ConfigTest {
                                + "adaptor.incrementalPollPeriodSecs=1700\n"
                                + "adaptor.docHeaderTimeoutSecs=50\n"
                                + "adaptor.docContentTimeoutSecs=190\n"
-                               + "adaptor.heartbeatTimeoutSecs=\n");
+                               + "adaptor.heartbeatTimeoutSecs=90\n");
     config.load(configFile);
     assertEquals(TimeUnit.SECONDS.toMillis(1700),
         config.getAdaptorIncrementalPollPeriodMillis());
@@ -347,7 +347,19 @@ public class ConfigTest {
         config.getAdaptorDocHeaderTimeoutMillis());
     assertEquals(TimeUnit.SECONDS.toMillis(190),
         config.getAdaptorDocContentTimeoutMillis());
-    assertEquals(TimeUnit.SECONDS.toMillis(50),
+    assertEquals(TimeUnit.SECONDS.toMillis(90),
+        config.getAdaptorHeartbeatTimeoutMillis());
+  }
+  
+  @Test
+  public void testNoHeartbeatTimeoutDefaultsToHeaderTimeout() throws Exception {
+    configFile.setFileContents("gsa.hostname=not_used\n"
+                               + "adaptor.docHeaderTimeoutSecs=51\n"
+                               + "adaptor.heartbeatTimeoutSecs=\n");
+    config.load(configFile);
+    assertEquals(TimeUnit.SECONDS.toMillis(51),
+        config.getAdaptorDocHeaderTimeoutMillis());
+    assertEquals(TimeUnit.SECONDS.toMillis(51),
         config.getAdaptorHeartbeatTimeoutMillis());
   }
 
@@ -357,9 +369,9 @@ public class ConfigTest {
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.incrementalPollPeriodSecs=";
     String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
-                                      Long.toString(Long.MAX_VALUE + 1)};
-    int y=0;
-    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+        Long.toString((Long.MAX_VALUE / 1000) + 1)};
+    int y = 0;
+    for (int i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
       try {
@@ -369,7 +381,7 @@ public class ConfigTest {
         y++;
       }
     }
-    assertEquals(y, invalidValuesToVerify.length);
+    assertEquals(invalidValuesToVerify.length, y);
   }
 
   @Test
@@ -379,9 +391,9 @@ public class ConfigTest {
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.heartbeatTimeoutSecs=";
     String invalidValuesToVerify[] = {"0", "-15", "NotValidValue",
-                                      Long.toString(Long.MAX_VALUE + 1)};
-    int y=0;
-    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+        Long.toString((Long.MAX_VALUE / 1000) + 1)};
+    int y = 0;
+    for (int i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
       try {
@@ -391,7 +403,7 @@ public class ConfigTest {
         y++;
       }
     }
-    assertEquals(y, invalidValuesToVerify.length);
+    assertEquals(invalidValuesToVerify.length, y);
   }
 
   @Test
@@ -400,9 +412,9 @@ public class ConfigTest {
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.docHeaderTimeoutSecs=";
     String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
-                                      Long.toString(Long.MAX_VALUE + 1)};
-    int y=0;
-    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+        Long.toString((Long.MAX_VALUE / 1000) + 1)};
+    int y = 0;
+    for (int i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
       try {
@@ -412,7 +424,7 @@ public class ConfigTest {
         y++;
       }
     }
-    assertEquals(y, invalidValuesToVerify.length);
+    assertEquals(invalidValuesToVerify.length, y);
   }
 
   @Test
@@ -421,9 +433,9 @@ public class ConfigTest {
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.docContentTimeoutSecs=";
     String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
-                                      Long.toString(Long.MAX_VALUE + 1)};
-    int y=0;
-    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+        Long.toString((Long.MAX_VALUE / 1000) + 1)};
+    int y = 0;
+    for (int i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
       try {
@@ -433,6 +445,6 @@ public class ConfigTest {
         y++;
       }
     }
-    assertEquals(y, invalidValuesToVerify.length);
+    assertEquals(invalidValuesToVerify.length, y);
   }
 }

--- a/test/com/google/enterprise/adaptor/ConfigTest.java
+++ b/test/com/google/enterprise/adaptor/ConfigTest.java
@@ -330,4 +330,48 @@ public class ConfigTest {
     config.load(configFile);
     assertEquals("\\\t\\\f", config.getValue("slash"));
   }
+
+  @Test
+  public void testPropertiesHeartbeatTimeoutMillis() throws Exception {
+    // docheartbeatTimeoutSecs=0 and docheartbeatTimeoutSecs=-15 are invalid
+    // it should use the default value for adaptor.docHeaderTimeoutSecs
+    // that is 30 seconds.
+    String putInConfig = " gsa.hostname=not_used\n"
+                         + "adaptor.heartbeatTimeoutSecs=";
+    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+      configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
+      config.load(configFile);
+      assertEquals(Long.parseLong("30000"),
+          config.getAdaptorHeartbeatTimeoutMillis());
+    }
+  }
+
+  @Test
+  public void testPropertiesDocHeaderTimeoutMillis() throws Exception {
+    // docHeaderTimeoutSecs=0 and docHeaderTimeoutSecs=-15 are invalid
+    // it should use the default value of 30 seconds.
+    String putInConfig = " gsa.hostname=not_used\n"
+                         + "adaptor.docHeaderTimeoutSecs=";
+    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+      configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
+      config.load(configFile);
+      assertEquals(Long.parseLong("30000"),
+          config.getAdaptorDocHeaderTimeoutMillis());
+    }
+  }
+
+  @Test
+  public void testPropertiesDocContentTimeoutMillis() throws Exception {
+    String putInConfig = " gsa.hostname=not_used\n"
+                         + "adaptor.docContentTimeoutSecs=";
+    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+      configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
+      config.load(configFile);
+      assertEquals(Long.parseLong("180000"),
+          config.getAdaptorDocContentTimeoutMillis());
+    }
+  }
 }

--- a/test/com/google/enterprise/adaptor/ConfigTest.java
+++ b/test/com/google/enterprise/adaptor/ConfigTest.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.adaptor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test cases for {@link Config}.
@@ -332,46 +334,105 @@ public class ConfigTest {
   }
 
   @Test
-  public void testPropertiesHeartbeatTimeoutMillis() throws Exception {
-    // docheartbeatTimeoutSecs=0 and docheartbeatTimeoutSecs=-15 are invalid
-    // it should use the default value for adaptor.docHeaderTimeoutSecs
-    // that is 30 seconds.
+  public void testValidValuesForTimeouts() throws Exception {
+    configFile.setFileContents("gsa.hostname=not_used\n"
+                               + "adaptor.incrementalPollPeriodSecs=1700\n"
+                               + "adaptor.docHeaderTimeoutSecs=50\n"
+                               + "adaptor.docContentTimeoutSecs=190\n"
+                               + "adaptor.heartbeatTimeoutSecs=\n");
+    config.load(configFile);
+    assertEquals(TimeUnit.SECONDS.toMillis(1700),
+        config.getAdaptorIncrementalPollPeriodMillis());
+    assertEquals(TimeUnit.SECONDS.toMillis(50),
+        config.getAdaptorDocHeaderTimeoutMillis());
+    assertEquals(TimeUnit.SECONDS.toMillis(190),
+        config.getAdaptorDocContentTimeoutMillis());
+    assertEquals(TimeUnit.SECONDS.toMillis(50),
+        config.getAdaptorHeartbeatTimeoutMillis());
+  }
+
+  @Test
+  public void testPropertiesIncrementalPollPeriodSecs() throws Exception {
+    // incrementalPollPeriodSecs=0 and incrementalPollPeriodSecs=-15 are invalid
     String putInConfig = " gsa.hostname=not_used\n"
-                         + "adaptor.heartbeatTimeoutSecs=";
-    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+                         + "adaptor.incrementalPollPeriodSecs=";
+    String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
+                                      Long.toString(Long.MAX_VALUE + 1)};
+    int y=0;
     for (int  i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
-      assertEquals(Long.parseLong("30000"),
-          config.getAdaptorHeartbeatTimeoutMillis());
+      try {
+        config.getAdaptorIncrementalPollPeriodMillis();
+      } catch (InvalidConfigurationException ice) {
+        assertTrue(ice.getMessage().contains("Invalid value for"));
+        y++;
+      }
     }
+    assertEquals(y, invalidValuesToVerify.length);
+  }
+
+  @Test
+  public void testPropertiesHeartbeatTimeoutMillis() throws Exception {
+    // docheartbeatTimeoutSecs=0 and docheartbeatTimeoutSecs=-15 are invalid
+    // Empty accepted, defaults to same value as adaptor.docHeaderTimeoutSecs.
+    String putInConfig = " gsa.hostname=not_used\n"
+                         + "adaptor.heartbeatTimeoutSecs=";
+    String invalidValuesToVerify[] = {"0", "-15", "NotValidValue",
+                                      Long.toString(Long.MAX_VALUE + 1)};
+    int y=0;
+    for (int  i = 0; i < invalidValuesToVerify.length; i++) {
+      configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
+      config.load(configFile);
+      try {
+        config.getAdaptorHeartbeatTimeoutMillis();
+      } catch (InvalidConfigurationException ice) {
+        assertTrue(ice.getMessage().contains("Invalid value for"));
+        y++;
+      }
+    }
+    assertEquals(y, invalidValuesToVerify.length);
   }
 
   @Test
   public void testPropertiesDocHeaderTimeoutMillis() throws Exception {
     // docHeaderTimeoutSecs=0 and docHeaderTimeoutSecs=-15 are invalid
-    // it should use the default value of 30 seconds.
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.docHeaderTimeoutSecs=";
-    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+    String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
+                                      Long.toString(Long.MAX_VALUE + 1)};
+    int y=0;
     for (int  i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
-      assertEquals(Long.parseLong("30000"),
-          config.getAdaptorDocHeaderTimeoutMillis());
+      try {
+        config.getAdaptorDocHeaderTimeoutMillis();
+      } catch (InvalidConfigurationException ice) {
+        assertTrue(ice.getMessage().contains("Invalid value for"));
+        y++;
+      }
     }
+    assertEquals(y, invalidValuesToVerify.length);
   }
 
   @Test
   public void testPropertiesDocContentTimeoutMillis() throws Exception {
+    // docContentTimeoutSecs=0 and docContentTimeoutSecs=-15 are invalid
     String putInConfig = " gsa.hostname=not_used\n"
                          + "adaptor.docContentTimeoutSecs=";
-    String invalidValuesToVerify[] = {"0", "-15", "", "NotValidValue"};
+    String invalidValuesToVerify[] = {"0", "-15", "NotValidValue", "",
+                                      Long.toString(Long.MAX_VALUE + 1)};
+    int y=0;
     for (int  i = 0; i < invalidValuesToVerify.length; i++) {
       configFile.setFileContents(putInConfig + invalidValuesToVerify[i]);
       config.load(configFile);
-      assertEquals(Long.parseLong("180000"),
-          config.getAdaptorDocContentTimeoutMillis());
+      try {
+        config.getAdaptorDocContentTimeoutMillis();
+      } catch (InvalidConfigurationException ice) {
+        assertTrue(ice.getMessage().contains("Invalid value for"));
+        y++;
+      }
     }
+    assertEquals(y, invalidValuesToVerify.length);
   }
 }


### PR DESCRIPTION
Adding code and tests to check the values of the following properties:
adaptor.docContentTimeoutSecs
adaptor.docHeaderTimeoutSecs
adaptor.heartbeatTimeoutSecs
In case the value set in config file is invalid, default value is returned and a warning is logged.