### PR TITLE
Allow connectors to add params for use by MetadataTransforms

### DIFF
--- a/src/com/google/enterprise/adaptor/AbstractDocIdPusher.java
+++ b/src/com/google/enterprise/adaptor/AbstractDocIdPusher.java
@@ -66,11 +66,25 @@ abstract class AbstractDocIdPusher implements DocIdPusher {
     return pushNamedResources(resources, null);
   }
 
-  /** Calls {@code pushGroupDefinitions(defs, caseSensitive, null)}. */
+  /**
+   * Calls {@code pushGroupDefinitions(defs, caseSensitive, true, null, null)}.
+   */
   @Override
   public GroupPrincipal pushGroupDefinitions(
       Map<GroupPrincipal, ? extends Collection<Principal>> defs,
       boolean caseSensitive) throws InterruptedException {
-    return pushGroupDefinitions(defs, caseSensitive, null);
+    return pushGroupDefinitions(defs, caseSensitive, true, null, null);
+  }
+
+  /**
+   * Calls
+   * {@code pushGroupDefinitions(defs, caseSensitive, true, null, handler)}.
+   */
+  @Override
+  public GroupPrincipal pushGroupDefinitions(
+      Map<GroupPrincipal, ? extends Collection<Principal>> defs,
+      boolean caseSensitive, ExceptionHandler handler)
+      throws InterruptedException {
+    return pushGroupDefinitions(defs, caseSensitive, true, null, handler);
   }
 }

--- a/src/com/google/enterprise/adaptor/CommandStreamParser.java
+++ b/src/com/google/enterprise/adaptor/CommandStreamParser.java
@@ -135,6 +135,13 @@ import java.util.regex.Pattern;
  * "meta-value=" -- specifies a metadata value associated with
  * immediately preceding metadata-name<p>
  *
+ * "param-name=" -- specifies a parameter key, to be followed by a parameter-value.
+ * Parameters are supplied to {@link MetadataTransforms} for use when making
+ * transforms or decisions.<p>
+ *
+ * "param-value=" -- specifies a parameter value associated with
+ * immediately preceding parameter-name<p>
+ *
  * "content" -- signals the beginning of binary content which
  * continues to the end of the file or stream<p>
  *
@@ -299,6 +306,8 @@ public class CommandStreamParser {
     MIME_TYPE("mime-type"),
     META_NAME("meta-name"),
     META_VALUE("meta-value"),
+    PARAM_NAME("param-name"),
+    PARAM_VALUE("param-value"),
     CONTENT("content"),
     AUTHZ_STATUS("authz-status"),
     SECURE("secure"),
@@ -482,6 +491,17 @@ public class CommandStreamParser {
               new Object[] {docId.getUniqueId(), metaName,
                 command.getArgument()});
           response.addMetadata(metaName, command.getArgument());
+          break;
+        case PARAM_NAME:
+          String paramName = command.getArgument();
+          command = readCommand();
+          if (command == null || command.getOperation() != Operation.PARAM_VALUE) {
+            throw new IOException("param-name must be immediately followed by param-value");
+          }
+          log.log(Level.FINEST, "Retriever: {0} has parameter {1}={2}",
+              new Object[] {docId.getUniqueId(), paramName,
+                command.getArgument()});
+          response.addParam(paramName, command.getArgument());
           break;
         case UP_TO_DATE:
           log.log(Level.FINEST, "Retriever: {0} is up to date.", docId.getUniqueId());

--- a/src/com/google/enterprise/adaptor/DocIdPusher.java
+++ b/src/com/google/enterprise/adaptor/DocIdPusher.java
@@ -184,6 +184,43 @@ public interface DocIdPusher {
       throws InterruptedException;
 
   /**
+   * Blocking call to push group definitions to GSA ends in success or
+   * when provided error handler gives up.  Can take significant time
+   * if errors arise.
+   *
+   * <p>A group definition consists of a group being defined
+   * and members, which is a list of users and groups.
+   *
+   * <p>If you plan on using the return code, then the provided map should have
+   * a predictable iteration order, like {@link java.util.TreeMap}.
+   *
+   * <p>An incremental push augments or updates any existing group definitions
+   * for the groupSource on the GSA. Otherwise, the supplied group definitions
+   * will wholly replace all existing definitions for the groupSource on the
+   * GSA.
+   *
+   * <p>A groupSource identifies the source of the group definitions. If
+   * provided, it must be a string of the form {@code [a-zA-Z_][a-zA-Z0-9_-]*}.
+   * If groupSource is {@code null}, then the {@code feed.name} configuration
+   * property is used.
+   *
+   * <p>If handler is {@code null}, then a default error handler is used.
+   *
+   * @param defs map of group definitions
+   * @param caseSensitive when comparing Principals
+   * @param incremental if {@code true} incremental update is done, otherwise
+   *        full replacement is done.
+   * @param groupSource
+   * @param handler for dealing with errors pushing
+   * @return {@code null} on success, otherwise the first GroupPrincipal to fail
+   * @throws InterruptedException if interrupted and no definitions were sent
+   */
+  public GroupPrincipal pushGroupDefinitions(
+      Map<GroupPrincipal, ? extends Collection<Principal>> defs,
+      boolean caseSensitive, boolean incremental, String groupSource,
+      ExceptionHandler handler) throws InterruptedException;
+
+  /**
    * Immutable feed attributes for a document identified by its {@code DocId}.
    */
   public static final class Record implements DocIdSender.Item {

--- a/src/com/google/enterprise/adaptor/DocIdSender.java
+++ b/src/com/google/enterprise/adaptor/DocIdSender.java
@@ -301,6 +301,8 @@ class DocIdSender extends AbstractDocIdPusher
       log.log(Level.INFO, "About to replace all groups from this data source "
           + "with {0} groups.", defs.size());
     }
+    // TODO (bmj): Track the accumulated feed size and compare to max feed file
+    // size allowed by the GSA?
     final int max = incremental ? config.getFeedMaxUrls() : defs.size();
 
     Iterator<Map.Entry<GroupPrincipal, T>> defsIterator

--- a/src/com/google/enterprise/adaptor/DocIdSender.java
+++ b/src/com/google/enterprise/adaptor/DocIdSender.java
@@ -292,19 +292,7 @@ class DocIdSender extends AbstractDocIdPusher
       handler = defaultErrorHandler;
     }
     boolean firstBatch = true;
-    // if we are not doing an incremental groups push (that is, we are replacing
-    // all groups from the given data source), we must do it in a single "batch"
-    // because if done in batches and a later batch fails, we would end up with
-    // an incomplete set of groups (which could end up giving a user access to
-    // search results that they are not supposed to have access to).
-    if (!incremental) {
-      log.log(Level.INFO, "About to replace all groups from this data source "
-          + "with {0} groups.", defs.size());
-    }
-    // TODO (bmj): Track the accumulated feed size and compare to max feed file
-    // size allowed by the GSA?
-    final int max = incremental ? config.getFeedMaxUrls() : defs.size();
-
+    final int max = config.getFeedMaxUrls();
     Iterator<Map.Entry<GroupPrincipal, T>> defsIterator
         = defs.entrySet().iterator();
     List<Map.Entry<GroupPrincipal, T>> batch

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -734,6 +733,7 @@ class DocumentHandler implements HttpHandler {
     private boolean crawlOnce;
     private boolean lock;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public DocumentResponse(HttpExchange ex, DocId docId, Thread thread) {
       this.ex = ex;
@@ -991,6 +991,15 @@ class DocumentHandler implements HttpHandler {
         throw new IllegalStateException("Already responded");
       }
       this.lock = lock;
+
+    }
+
+    @Override
+    public void addParam(String key, String value) {
+      if (state != State.SETUP) {
+        throw new IllegalStateException("Already responded");
+      }
+      params.put(key, value);
     }
 
     private long getWrittenContentSize() {
@@ -1213,7 +1222,6 @@ class DocumentHandler implements HttpHandler {
         log.log(Level.FINER, "Not performing Metadata transform.");
         return;
       }
-      Map<String, String> params = new HashMap<String, String>();
       params.put(KEY_DOC_ID, docId.getUniqueId());
       params.put(KEY_CONTENT_TYPE, finalContentType);
       if (null != lastModified) {
@@ -1243,7 +1251,7 @@ class DocumentHandler implements HttpHandler {
       }
       try {
         final String du = params.get(KEY_DISPLAY_URL);
-        if (!Strings.isNullOrEmpty(du) && !du.equals(origDisplayUrlStr)) {
+        if (!Strings.isNullOrEmpty(du)) {
           displayUrl = new URI(du);
         }
       } catch (URISyntaxException e) {

--- a/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
+++ b/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
@@ -105,9 +105,11 @@ public class GsaFeedFileSender {
   }
 
   private byte[] buildGroupsXmlMessage(String groupsource,
-      String xmlDocument) {
+      String xmlDocument, boolean incremental) {
     StringBuilder sb = new StringBuilder();
     buildPostParameter(sb, "groupsource", "text/plain", groupsource);
+    buildPostParameter(sb, "feedtype", "text/plain",
+        (incremental ? "incremental" : "full"));
     buildPostParameter(sb, "data", "text/xml", xmlDocument);
     sb.append("--").append(BOUNDARY).append("--").append(CRLF);
     return toEncodedBytes("" + sb);
@@ -257,12 +259,12 @@ public class GsaFeedFileSender {
    * Groupsource name is limited to [a-zA-Z_][a-zA-Z0-9_-]*.
    */
   void sendGroups(String groupsource, String xmlString,
-      boolean useCompression) throws IOException {
+      boolean useCompression, boolean incremental) throws IOException {
     if (!GROUPSOURCE_FORMAT.matcher(groupsource).matches()) {
       throw new IllegalArgumentException("Group source is invalid: "
           + groupsource);
     }
-    byte msg[] = buildGroupsXmlMessage(groupsource, xmlString);
+    byte msg[] = buildGroupsXmlMessage(groupsource, xmlString, incremental);
     // GSA only allows request content up to 1 MB to be compressed
     if (msg.length >= 1 * 1024 * 1024) {
       useCompression = false;

--- a/src/com/google/enterprise/adaptor/Response.java
+++ b/src/com/google/enterprise/adaptor/Response.java
@@ -213,4 +213,18 @@ public interface Response {
    *     to unlocked documents
    */
   public void setLock(boolean lock);
+
+  /**
+   * Adds a parameter to a Map for use by {@link MetadataTransforms} when making
+   * transforms or decisions. Params are data associated with the document,
+   * but might not be indexed and searchable. The {@code params} include the
+   * documents {@link DocId}, and values from {@link setLock},
+   * {@link setCrawlOnce}, {@code setDisplayUrl}, {@code setContentType},
+   * and {@code setLastModified}.
+   *
+   * @param key a key for a Map entry
+   * @param value the value for the Map entry for key
+   */
+  // TODO (bmj): Supply Params to ContentTransforms.
+  public void addParam(String key, String value);
 }

--- a/src/com/google/enterprise/adaptor/WrapperAdaptor.java
+++ b/src/com/google/enterprise/adaptor/WrapperAdaptor.java
@@ -435,9 +435,10 @@ abstract class WrapperAdaptor implements Adaptor {
     @Override
     public GroupPrincipal pushGroupDefinitions(
         Map<GroupPrincipal, ? extends Collection<Principal>> defs,
-        boolean caseSensitive, ExceptionHandler exceptionHandler)
-        throws InterruptedException {
-      return pusher.pushGroupDefinitions(defs, caseSensitive, exceptionHandler);
+        boolean caseSensitive, boolean incremental, String sourceName,
+        ExceptionHandler exceptionHandler) throws InterruptedException {
+      return pusher.pushGroupDefinitions(defs, caseSensitive, incremental,
+          sourceName, exceptionHandler);
     }
   }
 

--- a/src/com/google/enterprise/adaptor/WrapperAdaptor.java
+++ b/src/com/google/enterprise/adaptor/WrapperAdaptor.java
@@ -191,6 +191,11 @@ abstract class WrapperAdaptor implements Adaptor {
     public void setLock(boolean lock) {
       response.setLock(lock);
     }
+
+    @Override
+    public void addParam(String key, String value) {
+      response.addParam(key, value);
+    }
   }
 
   /**
@@ -252,6 +257,7 @@ abstract class WrapperAdaptor implements Adaptor {
     private boolean crawlOnce;
     private boolean lock;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public GetContentsResponse(OutputStream os) {
       this.os = os;
@@ -343,6 +349,11 @@ abstract class WrapperAdaptor implements Adaptor {
       this.lock = lock;
     }
 
+    @Override
+    public void addParam(String key, String value) {
+      params.put(key, value);
+    }
+
     public String getContentType() {
       return contentType;
     }
@@ -406,6 +417,10 @@ abstract class WrapperAdaptor implements Adaptor {
 
     public boolean isLock() {
       return lock;
+    }
+
+    public Map<String, String> getParams() {
+      return params;
     }
   }
 

--- a/test/com/google/enterprise/adaptor/AccumulatingDocIdPusher.java
+++ b/test/com/google/enterprise/adaptor/AccumulatingDocIdPusher.java
@@ -60,8 +60,8 @@ class AccumulatingDocIdPusher extends AbstractDocIdPusher {
   @Override
   public GroupPrincipal pushGroupDefinitions(
       Map<GroupPrincipal, ? extends Collection<Principal>> defs,
-      boolean caseSensitive, ExceptionHandler handler)
-      throws InterruptedException {
+      boolean caseSensitive, boolean incremental, String sourceName,
+      ExceptionHandler exceptionHandler) throws InterruptedException {
     groups.putAll(defs); 
     return null;
   }

--- a/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
@@ -98,6 +98,7 @@ public class CommandLineAdaptorTest {
     private static final Map<String, Date> ID_TO_LAST_MODIFIED;
     private static final Map<String, Date> ID_TO_LAST_CRAWLED;
     private static final Map<String, Metadata> ID_TO_METADATA;
+    private static final Map<String, Map<String, String>> ID_TO_PARAMS;
 
     static {
       Map<String, String> idToContent = new HashMap<String, String>();
@@ -134,6 +135,17 @@ public class CommandLineAdaptorTest {
       idToMetadata.put("1003", id1003Metadata.unmodifiableView());
 
       ID_TO_METADATA = Collections.unmodifiableMap(idToMetadata);
+
+      Map<String, Map<String, String>> idToParams
+          = new HashMap<String, Map<String, String>>();
+      Map<String, String> params = new HashMap<String, String>();
+      params.put("DoNotSkipDocument", "true");
+      params.put("LastAccessDate", "2000-10-08T14:56:00Z");
+      idToParams.put("1002", Collections.unmodifiableMap(params));
+      idToParams.put("1003",
+          Collections.unmodifiableMap(new HashMap<String, String>()));
+
+      ID_TO_PARAMS = Collections.unmodifiableMap(idToParams);
     }
 
     @Override
@@ -149,6 +161,7 @@ public class CommandLineAdaptorTest {
       Date lastModified = ID_TO_LAST_MODIFIED.get(docId);
       Date lastCrawled = ID_TO_LAST_CRAWLED.get(docId);
       String mimeType = ID_TO_MIME_TYPE.get(docId);
+      Map<String, String> params = ID_TO_PARAMS.get(docId);
 
       final StringBuffer result = new StringBuffer();
       result.append("GSA Adaptor Data Version 1 [\n]\n");
@@ -163,6 +176,12 @@ public class CommandLineAdaptorTest {
         for (Map.Entry<String, String> item : metadata) {
           result.append("meta-name=").append(item.getKey()).append("\n");
           result.append("meta-value=").append(item.getValue()).append("\n");
+        }
+      }
+      if (params != null) {
+        for (Map.Entry<String, String> item : params.entrySet()) {
+          result.append("param-name=").append(item.getKey()).append("\n");
+          result.append("param-value=").append(item.getValue()).append("\n");
         }
       }
       if (content != null) {
@@ -276,6 +295,7 @@ public class CommandLineAdaptorTest {
     private boolean lock;
     private boolean noContent;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public ContentsResponseTestMock(OutputStream os) {
       this.os = os;
@@ -368,6 +388,11 @@ public class CommandLineAdaptorTest {
       this.lock = lock;
     }
 
+    @Override
+    public void addParam(String key, String value) {
+      params.put(key, value);
+    }
+
     public String getContentType() {
       return contentType;
     }
@@ -419,6 +444,10 @@ public class CommandLineAdaptorTest {
 
     public boolean isLock() {
       return lock;
+    }
+
+    public Map<String, String> getParams() {
+      return params;
     }
   }
 
@@ -492,6 +521,9 @@ public class CommandLineAdaptorTest {
 
         assertEquals(CommandLineAdaptorTestMock.ID_TO_METADATA.get(docId.getUniqueId()),
             response.getMetadata());
+
+        assertEquals(CommandLineAdaptorTestMock.ID_TO_PARAMS.get(docId.getUniqueId()),
+            response.getParams());
 
         byte[] expected = CommandLineAdaptorTestMock.ID_TO_CONTENT.get(
             docId.getUniqueId()).getBytes();


### PR DESCRIPTION
This change allows the connector to insert metadata associated
with the document into the params that MetadataTransforms
receive. This data may be useful to the transforms, but
will not be sent to the GSA.