### PR TITLE
Allow connectors to add params for use by MetadataTransforms

### DIFF
--- a/src/com/google/enterprise/adaptor/CommandStreamParser.java
+++ b/src/com/google/enterprise/adaptor/CommandStreamParser.java
@@ -135,6 +135,13 @@ import java.util.regex.Pattern;
  * "meta-value=" -- specifies a metadata value associated with
  * immediately preceding metadata-name<p>
  *
+ * "param-name=" -- specifies a parameter key, to be followed by a parameter-value.
+ * Parameters are supplied to {@link MetadataTransforms} for use when making
+ * transforms or decisions.<p>
+ *
+ * "param-value=" -- specifies a parameter value associated with
+ * immediately preceding parameter-name<p>
+ *
  * "content" -- signals the beginning of binary content which
  * continues to the end of the file or stream<p>
  *
@@ -299,6 +306,8 @@ public class CommandStreamParser {
     MIME_TYPE("mime-type"),
     META_NAME("meta-name"),
     META_VALUE("meta-value"),
+    PARAM_NAME("param-name"),
+    PARAM_VALUE("param-value"),
     CONTENT("content"),
     AUTHZ_STATUS("authz-status"),
     SECURE("secure"),
@@ -482,6 +491,17 @@ public class CommandStreamParser {
               new Object[] {docId.getUniqueId(), metaName,
                 command.getArgument()});
           response.addMetadata(metaName, command.getArgument());
+          break;
+        case PARAM_NAME:
+          String paramName = command.getArgument();
+          command = readCommand();
+          if (command == null || command.getOperation() != Operation.PARAM_VALUE) {
+            throw new IOException("param-name must be immediately followed by param-value");
+          }
+          log.log(Level.FINEST, "Retriever: {0} has parameter {1}={2}",
+              new Object[] {docId.getUniqueId(), paramName,
+                command.getArgument()});
+          response.addParam(paramName, command.getArgument());
           break;
         case UP_TO_DATE:
           log.log(Level.FINEST, "Retriever: {0} is up to date.", docId.getUniqueId());

--- a/src/com/google/enterprise/adaptor/CommandStreamParser.java
+++ b/src/com/google/enterprise/adaptor/CommandStreamParser.java
@@ -501,7 +501,7 @@ public class CommandStreamParser {
           log.log(Level.FINEST, "Retriever: {0} has parameter {1}={2}",
               new Object[] {docId.getUniqueId(), paramName,
                 command.getArgument()});
-          response.addParam(paramName, command.getArgument());
+          response.setParam(paramName, command.getArgument());
           break;
         case UP_TO_DATE:
           log.log(Level.FINEST, "Retriever: {0} is up to date.", docId.getUniqueId());

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -734,6 +733,7 @@ class DocumentHandler implements HttpHandler {
     private boolean crawlOnce;
     private boolean lock;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public DocumentResponse(HttpExchange ex, DocId docId, Thread thread) {
       this.ex = ex;
@@ -991,6 +991,15 @@ class DocumentHandler implements HttpHandler {
         throw new IllegalStateException("Already responded");
       }
       this.lock = lock;
+
+    }
+
+    @Override
+    public void addParam(String key, String value) {
+      if (state != State.SETUP) {
+        throw new IllegalStateException("Already responded");
+      }
+      params.put(key, value);
     }
 
     private long getWrittenContentSize() {
@@ -1213,7 +1222,6 @@ class DocumentHandler implements HttpHandler {
         log.log(Level.FINER, "Not performing Metadata transform.");
         return;
       }
-      Map<String, String> params = new HashMap<String, String>();
       params.put(KEY_DOC_ID, docId.getUniqueId());
       params.put(KEY_CONTENT_TYPE, finalContentType);
       if (null != lastModified) {
@@ -1243,7 +1251,7 @@ class DocumentHandler implements HttpHandler {
       }
       try {
         final String du = params.get(KEY_DISPLAY_URL);
-        if (!Strings.isNullOrEmpty(du) && !du.equals(origDisplayUrlStr)) {
+        if (!Strings.isNullOrEmpty(du)) {
           displayUrl = new URI(du);
         }
       } catch (URISyntaxException e) {

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -991,13 +991,16 @@ class DocumentHandler implements HttpHandler {
         throw new IllegalStateException("Already responded");
       }
       this.lock = lock;
-
     }
 
     @Override
-    public void addParam(String key, String value) {
+    public void setParam(String key, String value) {
       if (state != State.SETUP) {
         throw new IllegalStateException("Already responded");
+      }
+      if (!key.startsWith("X-")) {
+        throw new IllegalArgumentException(
+            "The param key must start with 'X-'");
       }
       params.put(key, value);
     }
@@ -1251,7 +1254,7 @@ class DocumentHandler implements HttpHandler {
       }
       try {
         final String du = params.get(KEY_DISPLAY_URL);
-        if (!Strings.isNullOrEmpty(du)) {
+        if (!Strings.isNullOrEmpty(du) && !du.equals(origDisplayUrlStr)) {
           displayUrl = new URI(du);
         }
       } catch (URISyntaxException e) {

--- a/src/com/google/enterprise/adaptor/Response.java
+++ b/src/com/google/enterprise/adaptor/Response.java
@@ -213,4 +213,18 @@ public interface Response {
    *     to unlocked documents
    */
   public void setLock(boolean lock);
+
+  /**
+   * Adds a parameter to a Map for use by {@link MetadataTransforms} when making
+   * transforms or decisions. Params are data associated with the document,
+   * but might not be indexed and searchable. The {@code params} include the
+   * documents {@link DocId}, and values from {@link setLock},
+   * {@link setCrawlOnce}, {@code setDisplayUrl}, {@code setContentType},
+   * and {@code setLastModified}.
+   *
+   * @param key a key for a Map entry
+   * @param value the value for the Map entry for key
+   */
+  // TODO (bmj): Supply Params to ContentTransforms.
+  public void addParam(String key, String value);
 }

--- a/src/com/google/enterprise/adaptor/Response.java
+++ b/src/com/google/enterprise/adaptor/Response.java
@@ -215,15 +215,17 @@ public interface Response {
   public void setLock(boolean lock);
 
   /**
-   * Adds a parameter to a Map for use by {@link MetadataTransforms} when making
+   * Adds a parameter to a Map for use by
+   * {@link MetadataTransform MetadataTransforms} when making
    * transforms or decisions. Params are data associated with the document,
    * but might not be indexed and searchable. Before the metadata transforms are
    * called, the {@code params} are seeded with the document's {@link DocId},
    * and values from {@link setLock}, {@link setCrawlOnce},
    * {@code setDisplayUrl}, {@code setContentType}, and {@code setLastModified}.
-   * If the connector is setting a custom parameter (i.e. one not defined in
-   * {@link MetadataTransform}), the key must must start with {@code X-}
-   * to avoid possible name conflicts.
+   * <p>
+   * To avoid possible name conflicts with parameter entries supplied by the
+   * library, the key of a connector-supplied parameter must start with
+   * {@code X-}.
    * <p>
    * Example:
    * <code><pre>
@@ -232,6 +234,9 @@ public interface Response {
    *
    * @param key a key for a Map entry
    * @param value the value for the Map entry for key
+   * @throws IllegalArgumentException if key is not prefixed with {@code X-}
+   * @throws IllegalStateException if the response has been sent
+   * @throws NullPointerException if key is {@code null}
    */
   // TODO (bmj): Supply Params to ContentTransforms.
   public void setParam(String key, String value);

--- a/src/com/google/enterprise/adaptor/Response.java
+++ b/src/com/google/enterprise/adaptor/Response.java
@@ -217,14 +217,22 @@ public interface Response {
   /**
    * Adds a parameter to a Map for use by {@link MetadataTransforms} when making
    * transforms or decisions. Params are data associated with the document,
-   * but might not be indexed and searchable. The {@code params} include the
-   * documents {@link DocId}, and values from {@link setLock},
-   * {@link setCrawlOnce}, {@code setDisplayUrl}, {@code setContentType},
-   * and {@code setLastModified}.
+   * but might not be indexed and searchable. Before the metadata transforms are
+   * called, the {@code params} are seeded with the document's {@link DocId},
+   * and values from {@link setLock}, {@link setCrawlOnce},
+   * {@code setDisplayUrl}, {@code setContentType}, and {@code setLastModified}.
+   * If the connector is setting a custom parameter (i.e. one not defined in
+   * {@link MetadataTransform}), the key must must start with {@code X-}
+   * to avoid possible name conflicts.
+   * <p>
+   * Example:
+   * <code><pre>
+   * response.setParam("X-LastAccessDate", ISO8601.format(lastAccessDate));
+   * </pre></code>
    *
    * @param key a key for a Map entry
    * @param value the value for the Map entry for key
    */
   // TODO (bmj): Supply Params to ContentTransforms.
-  public void addParam(String key, String value);
+  public void setParam(String key, String value);
 }

--- a/src/com/google/enterprise/adaptor/WrapperAdaptor.java
+++ b/src/com/google/enterprise/adaptor/WrapperAdaptor.java
@@ -193,8 +193,8 @@ abstract class WrapperAdaptor implements Adaptor {
     }
 
     @Override
-    public void addParam(String key, String value) {
-      response.addParam(key, value);
+    public void setParam(String key, String value) {
+      response.setParam(key, value);
     }
   }
 
@@ -350,7 +350,7 @@ abstract class WrapperAdaptor implements Adaptor {
     }
 
     @Override
-    public void addParam(String key, String value) {
+    public void setParam(String key, String value) {
       params.put(key, value);
     }
 

--- a/src/com/google/enterprise/adaptor/WrapperAdaptor.java
+++ b/src/com/google/enterprise/adaptor/WrapperAdaptor.java
@@ -191,6 +191,11 @@ abstract class WrapperAdaptor implements Adaptor {
     public void setLock(boolean lock) {
       response.setLock(lock);
     }
+
+    @Override
+    public void addParam(String key, String value) {
+      response.addParam(key, value);
+    }
   }
 
   /**
@@ -252,6 +257,7 @@ abstract class WrapperAdaptor implements Adaptor {
     private boolean crawlOnce;
     private boolean lock;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public GetContentsResponse(OutputStream os) {
       this.os = os;
@@ -343,6 +349,11 @@ abstract class WrapperAdaptor implements Adaptor {
       this.lock = lock;
     }
 
+    @Override
+    public void addParam(String key, String value) {
+      params.put(key, value);
+    }
+
     public String getContentType() {
       return contentType;
     }
@@ -406,6 +417,10 @@ abstract class WrapperAdaptor implements Adaptor {
 
     public boolean isLock() {
       return lock;
+    }
+
+    public Map<String, String> getParams() {
+      return params;
     }
   }
 

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -767,6 +767,41 @@ public class DocumentHandlerTest {
   }
 
   @Test
+  public void testDroppingDocFromCustomParam() throws Exception {
+    List<MetadataTransform> transforms = new LinkedList<MetadataTransform>();
+    transforms.add(new MetadataTransform() {
+      @Override
+      public void transform(Metadata metadata, Map<String, String> params) {
+        if (params.containsKey("X-Do-Not-Index")) {
+          params.put("Transmission-Decision", "do-not-index");
+        }
+      }
+    });
+    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
+        Arrays.asList("t1"));
+    mockAdaptor = new MockAdaptor() {
+      @Override
+      public void getDocContent(Request request, Response response)
+          throws IOException, InterruptedException {
+        response.setParam("X-Do-Not-Index", null);
+        super.getDocContent(request, response);
+      }
+    };
+    String remoteIp = ex.getRemoteAddress().getAddress().getHostAddress();
+    DocumentHandler handler = createHandlerBuilder()
+        .setAdaptor(mockAdaptor)
+        .setFullAccessHosts(new String[] {remoteIp})
+        .setMetadataTransform(transform)
+        .build();
+    mockAdaptor.documentBytes = new byte[] {1, 2, 3};
+    handler.handle(ex);
+    assertEquals(404, ex.getResponseCode());
+    assertEquals(null,
+         ex.getResponseHeaders().getFirst("X-Gsa-External-Metadata"));
+    assertArrayEquals("Error 404: Not Found".getBytes(), ex.getResponseBytes());
+  }
+
+  @Test
   public void testAclTransform() throws Exception {
     AclTransform aclTransform = new AclTransform(Arrays.asList(
         new AclTransform.Rule(

--- a/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DocumentHandlerTest.java
@@ -777,8 +777,8 @@ public class DocumentHandlerTest {
         }
       }
     });
-    MetadataTransformPipeline transform = new MetadataTransformPipeline(transforms,
-        Arrays.asList("t1"));
+    MetadataTransformPipeline transform
+        = new MetadataTransformPipeline(transforms, Arrays.asList("t1"));
     mockAdaptor = new MockAdaptor() {
       @Override
       public void getDocContent(Request request, Response response)

--- a/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
@@ -389,7 +389,7 @@ public class CommandLineAdaptorTest {
     }
 
     @Override
-    public void addParam(String key, String value) {
+    public void setParam(String key, String value) {
       params.put(key, value);
     }
 

--- a/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
@@ -98,6 +98,7 @@ public class CommandLineAdaptorTest {
     private static final Map<String, Date> ID_TO_LAST_MODIFIED;
     private static final Map<String, Date> ID_TO_LAST_CRAWLED;
     private static final Map<String, Metadata> ID_TO_METADATA;
+    private static final Map<String, Map<String, String>> ID_TO_PARAMS;
 
     static {
       Map<String, String> idToContent = new HashMap<String, String>();
@@ -134,6 +135,17 @@ public class CommandLineAdaptorTest {
       idToMetadata.put("1003", id1003Metadata.unmodifiableView());
 
       ID_TO_METADATA = Collections.unmodifiableMap(idToMetadata);
+
+      Map<String, Map<String, String>> idToParams
+          = new HashMap<String, Map<String, String>>();
+      Map<String, String> params = new HashMap<String, String>();
+      params.put("DoNotSkipDocument", "true");
+      params.put("LastAccessDate", "2000-10-08T14:56:00Z");
+      idToParams.put("1002", Collections.unmodifiableMap(params));
+      idToParams.put("1003",
+          Collections.unmodifiableMap(new HashMap<String, String>()));
+
+      ID_TO_PARAMS = Collections.unmodifiableMap(idToParams);
     }
 
     @Override
@@ -149,6 +161,7 @@ public class CommandLineAdaptorTest {
       Date lastModified = ID_TO_LAST_MODIFIED.get(docId);
       Date lastCrawled = ID_TO_LAST_CRAWLED.get(docId);
       String mimeType = ID_TO_MIME_TYPE.get(docId);
+      Map<String, String> params = ID_TO_PARAMS.get(docId);
 
       final StringBuffer result = new StringBuffer();
       result.append("GSA Adaptor Data Version 1 [\n]\n");
@@ -163,6 +176,12 @@ public class CommandLineAdaptorTest {
         for (Map.Entry<String, String> item : metadata) {
           result.append("meta-name=").append(item.getKey()).append("\n");
           result.append("meta-value=").append(item.getValue()).append("\n");
+        }
+      }
+      if (params != null) {
+        for (Map.Entry<String, String> item : params.entrySet()) {
+          result.append("param-name=").append(item.getKey()).append("\n");
+          result.append("param-value=").append(item.getValue()).append("\n");
         }
       }
       if (content != null) {
@@ -276,6 +295,7 @@ public class CommandLineAdaptorTest {
     private boolean lock;
     private boolean noContent;
     private Map<String, Acl> fragments = new TreeMap<String, Acl>();
+    private Map<String, String> params = new TreeMap<String, String>();
 
     public ContentsResponseTestMock(OutputStream os) {
       this.os = os;
@@ -368,6 +388,11 @@ public class CommandLineAdaptorTest {
       this.lock = lock;
     }
 
+    @Override
+    public void addParam(String key, String value) {
+      params.put(key, value);
+    }
+
     public String getContentType() {
       return contentType;
     }
@@ -419,6 +444,10 @@ public class CommandLineAdaptorTest {
 
     public boolean isLock() {
       return lock;
+    }
+
+    public Map<String, String> getParams() {
+      return params;
     }
   }
 
@@ -492,6 +521,9 @@ public class CommandLineAdaptorTest {
 
         assertEquals(CommandLineAdaptorTestMock.ID_TO_METADATA.get(docId.getUniqueId()),
             response.getMetadata());
+
+        assertEquals(CommandLineAdaptorTestMock.ID_TO_PARAMS.get(docId.getUniqueId()),
+            response.getParams());
 
         byte[] expected = CommandLineAdaptorTestMock.ID_TO_CONTENT.get(
             docId.getUniqueId()).getBytes();


### PR DESCRIPTION
This change allows the connector to insert metadata associated
with the document into the params that MetadataTransforms
receive. This data may be useful to the transforms, but
will not be sent to the GSA.