### PR TITLE
Set the dist file suffix from the auto-detected version.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -215,6 +215,14 @@
     </exec>
     <!-- Set version if git describe failed. -->
     <property name="adaptorlib.version" value="unknown-${DSTAMP}"/>
+
+    <!-- Use the version without the "v" prefix for file names. -->
+    <loadresource property="adaptorlib.suffix">
+      <propertyresource name="adaptorlib.version"/>
+      <filterchain>
+          <replaceregex pattern="^(v(\d))?" replace="-\2"/>
+      </filterchain>
+    </loadresource>
   </target>
 
   <target name="dist" description="Generate distribution binaries"
@@ -238,7 +246,7 @@
     <copy file="THIRDPARTYLICENSE.txt" todir="${dist.staging.dir}"/>
 
     <!-- adaptor.jar -->
-    <jar destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}.jar"
+    <jar destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}.jar"
       basedir="${build-src.dir}" excludes="${adaptor.pkg.dir}/examples/**">
       <manifest>
         <section name="com/google/enterprise/adaptor/">
@@ -252,7 +260,7 @@
     </jar>
 
     <!-- adaptor-src.jar -->
-    <jar destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-src.jar"
+    <jar destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-src.jar"
       basedir="${src.dir}" excludes="${adaptor.pkg.dir}/examples/**">
       <fileset dir="${resource.dir}"/>
     </jar>
@@ -276,13 +284,12 @@
       <!-- Provide an empty manifest to encourage mergewithoutmain to function.
            See https://issues.apache.org/bugzilla/show_bug.cgi?id=54171 . -->
       <manifest/>
-      <zipfileset src="${dist.staging.dir}/adaptor-${adaptorlib.version}.jar"/>
+      <zipfileset src="${dist.staging.dir}/adaptor${adaptorlib.suffix}.jar"/>
       <zipgroupfileset dir="${dist.staging.dir}/lib"/>
     </jar>
     <!-- Re-save JAR without signing keys, since keeping them in the JAR causes
          security exceptions. -->
-    <zip
-      destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-withlib.jar">
+    <zip destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-withlib.jar">
       <zipfileset excludes="META-INF/**/*.DSA,META-INF/**/*.SF"
         src="${build.dir}/dist/adaptor-withlib.tmp.jar"/>
     </zip>
@@ -292,7 +299,7 @@
       property="tmp.examples.zipgroup">
       <map from="${lib.dir}/" to=""/>
     </pathconvert>
-    <jar destfile="${dist.staging.dir}/examples/adaptor-${adaptorlib.version}-examples.jar"
+    <jar destfile="${dist.staging.dir}/examples/adaptor${adaptorlib.suffix}-examples.jar"
       basedir="${build-src.dir}" includes="${adaptor.pkg.dir}/examples/**">
       <manifest>
         <section name="com/google/enterprise/adaptor/examples/">
@@ -313,13 +320,13 @@
     </copy>
 
     <!-- adaptor-docs.zip -->
-    <zip destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-docs.zip"
+    <zip destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-docs.zip"
       basedir="${javadoc.dir}"/>
 
     <!-- Produce final distribution files -->
 
     <!-- adaptor-src.zip -->
-    <zip destfile="${dist.dir}/adaptor-${adaptorlib.version}-src.zip"
+    <zip destfile="${dist.dir}/adaptor${adaptorlib.suffix}-src.zip"
       basedir="${basedir}">
       <exclude name="**/.*/**"/>
 
@@ -344,15 +351,15 @@
 
     <!-- adaptor-bin.zip -->
     <move file="${dist.staging.dir}"
-      tofile="${build.dir}/dist/adaptor-${adaptorlib.version}"/>
-    <zip destfile="${dist.dir}/adaptor-${adaptorlib.version}-bin.zip"
-      basedir="${build.dir}/dist/adaptor-${adaptorlib.version}"/>
+      tofile="${build.dir}/dist/adaptor${adaptorlib.suffix}"/>
+    <zip destfile="${dist.dir}/adaptor${adaptorlib.suffix}-bin.zip"
+      basedir="${build.dir}/dist/adaptor${adaptorlib.suffix}"/>
   </target>
 
   <!-- Build stand-alone AdaptorTemplate.jar for testing purposes. -->
   <target name="adaptor-template" description="AdaptorTemplate jar"
     depends="package">
-    <jar destfile="${build.dir}/dist/adaptor-${adaptorlib.version}/AdaptorTemplate.jar"
+    <jar destfile="${build.dir}/dist/adaptor${adaptorlib.suffix}/AdaptorTemplate.jar"
       basedir="${build-src.dir}"
       includes="${adaptor.pkg.dir}/**/AdaptorTemplate.class">
       <manifest>
@@ -363,7 +370,7 @@
         <attribute name="Main-Class"
           value="com.google.enterprise.adaptor.examples.AdaptorTemplate" />
         <attribute name="Class-Path"
-          value="adaptor-${adaptorlib.version}-withlib.jar" />
+          value="adaptor${adaptorlib.suffix}-withlib.jar" />
       </manifest>
     </jar>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -215,14 +215,6 @@
     </exec>
     <!-- Set version if git describe failed. -->
     <property name="adaptorlib.version" value="unknown-${DSTAMP}"/>
-
-    <!-- Use the version without the "v" prefix for file names. -->
-    <loadresource property="adaptorlib.suffix">
-      <propertyresource name="adaptorlib.version"/>
-      <filterchain>
-          <replaceregex pattern="^(v(\d))?" replace="-\2"/>
-      </filterchain>
-    </loadresource>
   </target>
 
   <target name="dist" description="Generate distribution binaries"
@@ -239,6 +231,15 @@
     <mkdir dir="${build.dir}/dist/staging"/>
     <mkdir dir="${build.dir}/dist/staging/examples"/>
     <mkdir dir="${dist.dir}"/>
+
+    <!-- Set the file name suffix from the version. Add a leading dash,
+         and strip a leading "v" prefix if it is followed by a digit. -->
+    <loadresource property="adaptorlib.suffix">
+      <propertyresource name="adaptorlib.version"/>
+      <filterchain>
+          <replaceregex pattern="^(v(?=\d))?" replace="-"/>
+      </filterchain>
+    </loadresource>
 
     <!-- Produce intermediate distribution files -->
 

--- a/build.xml
+++ b/build.xml
@@ -26,13 +26,6 @@
       value="${adaptor.pkg.name}.examples.AdaptorTemplate"/>
   <property name="adaptor.args" value=""/>
   <property name="cobertura.dir" value="${basedir}/../cobertura/"/>
-  <!-- Adaptor suffix for distribution files. Useful for placing version numbers
-       on our jars. -->
-  <condition property="adaptorlib.suffix" value="-${adaptorlib.version}">
-    <isset property="adaptorlib.version"/>
-  </condition>
-  <!-- If adaptorlib.version isn't set, simply use the current date. -->
-  <property name="adaptorlib.suffix" value="-${DSTAMP}"/>
 
   <path id="adaptorlib.build.classpath">
     <fileset dir="${lib.dir}">
@@ -221,7 +214,7 @@
       <arg value="--always"/>
     </exec>
     <!-- Set version if git describe failed. -->
-    <property name="adaptorlib.version" value="unknown"/>
+    <property name="adaptorlib.version" value="unknown-${DSTAMP}"/>
   </target>
 
   <target name="dist" description="Generate distribution binaries"
@@ -245,7 +238,7 @@
     <copy file="THIRDPARTYLICENSE.txt" todir="${dist.staging.dir}"/>
 
     <!-- adaptor.jar -->
-    <jar destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}.jar"
+    <jar destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}.jar"
       basedir="${build-src.dir}" excludes="${adaptor.pkg.dir}/examples/**">
       <manifest>
         <section name="com/google/enterprise/adaptor/">
@@ -259,7 +252,7 @@
     </jar>
 
     <!-- adaptor-src.jar -->
-    <jar destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-src.jar"
+    <jar destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-src.jar"
       basedir="${src.dir}" excludes="${adaptor.pkg.dir}/examples/**">
       <fileset dir="${resource.dir}"/>
     </jar>
@@ -283,12 +276,13 @@
       <!-- Provide an empty manifest to encourage mergewithoutmain to function.
            See https://issues.apache.org/bugzilla/show_bug.cgi?id=54171 . -->
       <manifest/>
-      <zipfileset src="${dist.staging.dir}/adaptor${adaptorlib.suffix}.jar"/>
+      <zipfileset src="${dist.staging.dir}/adaptor-${adaptorlib.version}.jar"/>
       <zipgroupfileset dir="${dist.staging.dir}/lib"/>
     </jar>
     <!-- Re-save JAR without signing keys, since keeping them in the JAR causes
          security exceptions. -->
-    <zip destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-withlib.jar">
+    <zip
+      destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-withlib.jar">
       <zipfileset excludes="META-INF/**/*.DSA,META-INF/**/*.SF"
         src="${build.dir}/dist/adaptor-withlib.tmp.jar"/>
     </zip>
@@ -298,7 +292,7 @@
       property="tmp.examples.zipgroup">
       <map from="${lib.dir}/" to=""/>
     </pathconvert>
-    <jar destfile="${dist.staging.dir}/examples/adaptor${adaptorlib.suffix}-examples.jar"
+    <jar destfile="${dist.staging.dir}/examples/adaptor-${adaptorlib.version}-examples.jar"
       basedir="${build-src.dir}" includes="${adaptor.pkg.dir}/examples/**">
       <manifest>
         <section name="com/google/enterprise/adaptor/examples/">
@@ -319,13 +313,13 @@
     </copy>
 
     <!-- adaptor-docs.zip -->
-    <zip destfile="${dist.staging.dir}/adaptor${adaptorlib.suffix}-docs.zip"
+    <zip destfile="${dist.staging.dir}/adaptor-${adaptorlib.version}-docs.zip"
       basedir="${javadoc.dir}"/>
 
     <!-- Produce final distribution files -->
 
     <!-- adaptor-src.zip -->
-    <zip destfile="${dist.dir}/adaptor${adaptorlib.suffix}-src.zip"
+    <zip destfile="${dist.dir}/adaptor-${adaptorlib.version}-src.zip"
       basedir="${basedir}">
       <exclude name="**/.*/**"/>
 
@@ -350,15 +344,15 @@
 
     <!-- adaptor-bin.zip -->
     <move file="${dist.staging.dir}"
-      tofile="${build.dir}/dist/adaptor${adaptorlib.suffix}"/>
-    <zip destfile="${dist.dir}/adaptor${adaptorlib.suffix}-bin.zip"
-      basedir="${build.dir}/dist/adaptor${adaptorlib.suffix}"/>
+      tofile="${build.dir}/dist/adaptor-${adaptorlib.version}"/>
+    <zip destfile="${dist.dir}/adaptor-${adaptorlib.version}-bin.zip"
+      basedir="${build.dir}/dist/adaptor-${adaptorlib.version}"/>
   </target>
 
   <!-- Build stand-alone AdaptorTemplate.jar for testing purposes. -->
   <target name="adaptor-template" description="AdaptorTemplate jar"
     depends="package">
-    <jar destfile="${build.dir}/dist/adaptor${adaptorlib.suffix}/AdaptorTemplate.jar"
+    <jar destfile="${build.dir}/dist/adaptor-${adaptorlib.version}/AdaptorTemplate.jar"
       basedir="${build-src.dir}"
       includes="${adaptor.pkg.dir}/**/AdaptorTemplate.class">
       <manifest>
@@ -369,7 +363,7 @@
         <attribute name="Main-Class"
           value="com.google.enterprise.adaptor.examples.AdaptorTemplate" />
         <attribute name="Class-Path"
-          value="adaptor${adaptorlib.suffix}-withlib.jar" />
+          value="adaptor-${adaptorlib.version}-withlib.jar" />
       </manifest>
     </jar>
   </target>


### PR DESCRIPTION
adaptorlib.version is auto-detected using git, and adaptorlib.suffix
is set automatically from the version. Each property can be overridden
independently from the command line.

Previously, adaptorlib.suffix was set before adaptorlib.version was
set, so you always had to set adaptorlib.suffix on the command line.
Also, if you set adaptorlib.version on the command line,
adaptorlib.suffix would incorrectly include the leading "v" from the
version number, if the standard "v1.2.3" format was used.

Now, most uses of the "package" target, including releases, can be
done without command line arguments.

When used without git, the auto-detected version used in the JAR
manifest was "unknown", and the default suffix was "-yyyyMMdd".
Now the version will be "unknown-yyyyMMdd" and the suffix will be
"-unknown-yyyyMMdd".