### PR TITLE
Move addParam to Response2, a new subinterface of Response.

### DIFF
--- a/src/com/google/enterprise/adaptor/Adaptor.java
+++ b/src/com/google/enterprise/adaptor/Adaptor.java
@@ -46,7 +46,8 @@ public interface Adaptor {
    * IOException} or {@link RuntimeException}. In the case of an error, the GSA
    * will determine if and when to retry.
    * @param request info about document being sought
-   * @param response place to put document data
+   * @param response place to put document data; this argument will always
+   *     implement {@link Response2}
    * @throws IOException if getting data fails
    * @throws InterruptedException if an IO operation throws it
    */

--- a/src/com/google/enterprise/adaptor/CommandStreamParser.java
+++ b/src/com/google/enterprise/adaptor/CommandStreamParser.java
@@ -493,6 +493,10 @@ public class CommandStreamParser {
           response.addMetadata(metaName, command.getArgument());
           break;
         case PARAM_NAME:
+          if (!(response instanceof Response2)) {
+            throw new IOException(
+                "param-name is not supported by " + response.getClass());
+          }
           String paramName = command.getArgument();
           command = readCommand();
           if (command == null || command.getOperation() != Operation.PARAM_VALUE) {
@@ -501,7 +505,7 @@ public class CommandStreamParser {
           log.log(Level.FINEST, "Retriever: {0} has parameter {1}={2}",
               new Object[] {docId.getUniqueId(), paramName,
                 command.getArgument()});
-          response.addParam(paramName, command.getArgument());
+          ((Response2) response).addParam(paramName, command.getArgument());
           break;
         case UP_TO_DATE:
           log.log(Level.FINEST, "Retriever: {0} is up to date.", docId.getUniqueId());

--- a/src/com/google/enterprise/adaptor/DocumentHandler.java
+++ b/src/com/google/enterprise/adaptor/DocumentHandler.java
@@ -706,7 +706,7 @@ class DocumentHandler implements HttpHandler {
    * <p>{@link #getOutputStream} and {@link #complete} are the main methods that
    * need to be very aware of all the different possibilities.
    */
-  private class DocumentResponse implements Response {
+  private class DocumentResponse implements Response2 {
     private Thread workingThread;
     private State state = State.SETUP;
     private HttpExchange ex;

--- a/src/com/google/enterprise/adaptor/Response.java
+++ b/src/com/google/enterprise/adaptor/Response.java
@@ -14,13 +14,15 @@
 
 package com.google.enterprise.adaptor;
 
+import com.google.enterprise.adaptor.testing.UnsupportedResponse;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Date;
 
 /**
- * Interface provided to {@link Adaptor#getDocContent
+ * Base interface provided to {@link Adaptor#getDocContent
  * Adaptor.getDocContent(Request, Response)} for performing the actions needed
  * to satisfy a request.
  *
@@ -33,6 +35,11 @@ import java.util.Date;
  * {@link Request#hasChangedSinceLastAccess} and call {@link
  * #respondNotModified} when it is {@code true}. This prevents the Adaptor from
  * ever needing to retrieve the document contents and metadata.
+ *
+ * <p>This interface should not be implemented directly for unit testing.
+ * Instead, use a mocking framework, such as Mockito, a
+ * {@code java.lang.reflect.Proxy}, or extend the {@link UnsupportedResponse}
+ * class.
  */
 public interface Response {
   /**
@@ -213,18 +220,4 @@ public interface Response {
    *     to unlocked documents
    */
   public void setLock(boolean lock);
-
-  /**
-   * Adds a parameter to a Map for use by {@link MetadataTransforms} when making
-   * transforms or decisions. Params are data associated with the document,
-   * but might not be indexed and searchable. The {@code params} include the
-   * documents {@link DocId}, and values from {@link setLock},
-   * {@link setCrawlOnce}, {@code setDisplayUrl}, {@code setContentType},
-   * and {@code setLastModified}.
-   *
-   * @param key a key for a Map entry
-   * @param value the value for the Map entry for key
-   */
-  // TODO (bmj): Supply Params to ContentTransforms.
-  public void addParam(String key, String value);
 }

--- a/src/com/google/enterprise/adaptor/Response2.java
+++ b/src/com/google/enterprise/adaptor/Response2.java
@@ -1,0 +1,45 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor;
+
+import com.google.enterprise.adaptor.testing.UnsupportedResponse;
+
+/**
+ * Extended interface provided to {@link Adaptor#getDocContent
+ * Adaptor.getDocContent(Request, Response)} for performing the actions needed
+ * to satisfy a request.
+ *
+ * <p>This interface should not be implemented directly for unit testing.
+ * Instead, use a mocking framework, such as Mockito, a
+ * {@code java.lang.reflect.Proxy}, or extend the {@link UnsupportedResponse}
+ * class.
+ */
+public interface Response2 extends Response {
+  /**
+   * Adds a parameter to a map for use by {@link MetadataTransform
+   * MetadataTransforms} when making transforms or decisions. Params
+   * are data associated with the document, but might not be indexed
+   * and searchable. The {@code params} include the document's {@link
+   * DocId}, and values from {@link #setLock setLock}, {@link
+   * #setCrawlOnce setCrawlOnce}, {@link #setDisplayUrl
+   * setDisplayUrl}, {@link #setContentType setContentType}, and
+   * {@link #setLastModified setLastModified}.
+   *
+   * @param key a key for a Map entry
+   * @param value the value for the Map entry for key
+   */
+  // TODO (bmj): Supply Params to ContentTransforms.
+  public void addParam(String key, String value);
+}

--- a/src/com/google/enterprise/adaptor/WrapperAdaptor.java
+++ b/src/com/google/enterprise/adaptor/WrapperAdaptor.java
@@ -100,9 +100,14 @@ abstract class WrapperAdaptor implements Adaptor {
   /**
    * Passes through all operations to wrapped {@code Response}.
    */
-  public static class WrapperResponse implements Response {
+  public static class WrapperResponse implements Response2 {
     private Response response;
 
+    /**
+     * If {@code response} is a {@code Response2}, then the {@code addParam}
+     * method is supported on this instance. Otherwise, {@code addParam}
+     * will throw an exception.
+     */
     public WrapperResponse(Response response) {
       this.response = response;
     }
@@ -192,9 +197,18 @@ abstract class WrapperAdaptor implements Adaptor {
       response.setLock(lock);
     }
 
+    /**
+     * @throws UnsupportedOperationException if the wrapped {@code Response}
+     *     is not a {@code Response2}
+     */
     @Override
     public void addParam(String key, String value) {
-      response.addParam(key, value);
+      if (response instanceof Response2) {
+        ((Response2) response).addParam(key, value);
+      } else {
+        throw new UnsupportedOperationException(
+            "addParam is not supported by " + response.getClass());
+      }
     }
   }
 
@@ -219,8 +233,6 @@ abstract class WrapperAdaptor implements Adaptor {
     public boolean canRespondWithNoContent(Date lastModified) {
       return false;
     }
-    
-    
 
     @Override
     public Date getLastAccessTime() {
@@ -238,7 +250,7 @@ abstract class WrapperAdaptor implements Adaptor {
    * {@link Adaptor}. It does not support {@link #respondNotModified}. Be sure
    * to check {@link #isNotFound()}.
    */
-  public static class GetContentsResponse implements Response {
+  public static class GetContentsResponse implements Response2 {
     private OutputStream os;
     private String contentType;
     private Date lastModified;

--- a/src/com/google/enterprise/adaptor/testing/UnsupportedResponse.java
+++ b/src/com/google/enterprise/adaptor/testing/UnsupportedResponse.java
@@ -1,0 +1,122 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor.testing;
+
+import com.google.enterprise.adaptor.Acl;
+import com.google.enterprise.adaptor.Response;
+import com.google.enterprise.adaptor.Response2;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Date;
+
+/**
+ * An implementation of {@link Response2} that throws an
+ * {@code UnsupportedOperationException} if any method is called.
+ *
+ * <p>This class is intended to be extended for unit testing, rather
+ * than implementing {@link Response} or {@link Response2} directly.
+ */
+public class UnsupportedResponse implements Response2 {
+  /** @throws UnsupportedOperationException always */
+  public void respondNotModified() throws IOException {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void respondNotFound() throws IOException {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void respondNoContent() throws IOException {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  public OutputStream getOutputStream() throws IOException {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setContentType(String contentType) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setLastModified(Date lastModified) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void addMetadata(String key, String value) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setAcl(Acl acl) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void putNamedResource(String fragment, Acl acl) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setSecure(boolean secure) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void addAnchor(URI uri, String text) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setNoIndex(boolean noIndex) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setNoFollow(boolean noFollow) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setNoArchive(boolean noArchive) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setDisplayUrl(URI displayUrl) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setCrawlOnce(boolean crawlOnce) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void setLock(boolean lock) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+
+  /** @throws UnsupportedOperationException always */
+  public void addParam(String key, String value) {
+    throw new UnsupportedOperationException("UnsupportedResponse was called");
+  }
+}

--- a/test/com/google/enterprise/adaptor/WrapperAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/WrapperAdaptorTest.java
@@ -1,0 +1,59 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/** Unit tests for {@link WrapperAdaptor}. */
+public class WrapperAdaptorTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testWrapperResponse_addParam_Response() {
+    WrapperAdaptor.WrapperResponse wrapper =
+        new WrapperAdaptor.WrapperResponse(newProxyInstance(Response.class));
+    wrapper.setLock(false);
+    thrown.expect(UnsupportedOperationException.class);
+    wrapper.addParam("foo", "bar");
+  }
+
+  @Test
+  public void testWrapperResponse_addParam_Response2() {
+    WrapperAdaptor.WrapperResponse wrapper =
+        new WrapperAdaptor.WrapperResponse(newProxyInstance(Response2.class));
+    wrapper.setLock(false);
+    wrapper.addParam("foo", "bar");
+  }
+
+  /** Gets a proxy for the given class that does nothing. */
+  private <T> T newProxyInstance(Class<T> clazz) {
+    return clazz.cast(
+        Proxy.newProxyInstance(clazz.getClassLoader(),
+            new Class<?>[] { clazz },
+            new InvocationHandler() {
+              public Object invoke(Object proxy, Method method, Object[] args) {
+                // This does not work with primitive return types.
+                return null;
+              }
+            }));
+  }
+}

--- a/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
@@ -26,7 +26,7 @@ import com.google.enterprise.adaptor.DocId;
 import com.google.enterprise.adaptor.GroupPrincipal;
 import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.Request;
-import com.google.enterprise.adaptor.Response;
+import com.google.enterprise.adaptor.Response2;
 import com.google.enterprise.adaptor.UserPrincipal;
 import com.google.enterprise.adaptor.prebuilt.StreamingCommand.InputSource;
 import com.google.enterprise.adaptor.prebuilt.StreamingCommand.OutputSink;
@@ -276,7 +276,7 @@ public class CommandLineAdaptorTest {
     }
   }
 
-  private static class ContentsResponseTestMock implements Response {
+  private static class ContentsResponseTestMock implements Response2 {
     private OutputStream os;
     private String contentType;
     private Date lastModified;


### PR DESCRIPTION
This preserves source and binary compatibility when adding new methods
to the interfaces. In the future, new methods can be added to the
Response2 interface, rather than creating additional subinterfaces.

When calling an adaptor, an instance of Response2 is always provided.

Adaptor implementers who want to use the methods of Response2 should
cast the Response parameter passed to getDocContent to Response2, and
for unit tests, should extend the new UnsupportedResponse class,
rather than implementing Response2 directly.