### PR TITLE
Use NoColor formatter for log files more like connectors

### DIFF
--- a/logging.properties
+++ b/logging.properties
@@ -1,6 +1,8 @@
-handlers = java.util.logging.FileHandler,java.util.logging.ConsoleHandler
+.level = INFO
+com.google.enterprise.adaptor.level = ALL
 
-.level = FINER
+handlers = java.util.logging.ConsoleHandler
+#handlers = java.util.logging.ConsoleHandler,java.util.logging.FileHandler
 
 java.util.logging.ConsoleHandler.level = FINEST
 java.util.logging.ConsoleHandler.formatter = com.google.enterprise.adaptor.CustomFormatter


### PR DESCRIPTION
This change makes logging.properties look more like the
those of the connectors. It also disables logging to files
by default.