### PR TITLE
Improve log messages in SkipDocumentFilter and RegexFilter

### DIFF
--- a/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
@@ -21,6 +21,7 @@ import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.MetadataTransform;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -185,7 +186,15 @@ public class RegexFilter implements MetadataTransform {
    */
   private boolean foundInMetadata(Metadata metadata) {
     boolean found = false;
-    for (String value : metadata.getAllValues(key)) {
+    Set<String> values = metadata.getAllValues(key);
+    if (values.isEmpty()) {
+      if (metadata.getKeys().contains(key)) {
+        log.finest("No values for key `" + key + "' in metadata.");
+      } else {
+        log.finest("No key `" + key + "' in metadata.");
+      }
+    }
+    for (String value : values) {
       if (pattern.matcher(value).find()) {
         found = true;
         break;
@@ -205,6 +214,8 @@ public class RegexFilter implements MetadataTransform {
     boolean found = false;
     if (params.containsKey(key)) {
       found = pattern.matcher(params.get(key)).find();
+    } else {
+      log.finest("No key `" + key + "' in params.");
     }
     log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
         + key + "' in params.");

--- a/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
@@ -189,9 +189,9 @@ public class RegexFilter implements MetadataTransform {
     Set<String> values = metadata.getAllValues(key);
     if (values.isEmpty() && log.isLoggable(Level.FINEST)) {
       if (metadata.getKeys().contains(key)) {
-        log.finest("No values for key `" + key + "' in metadata.");
+        log.log(Level.FINEST, "No values for key {0} in metadata.", key);
       } else {
-        log.finest("No key `" + key + "' in metadata.");
+        log.log(Level.FINEST, "No key {0} in metadata.", key);
       }
     }
     for (String value : values) {
@@ -200,8 +200,8 @@ public class RegexFilter implements MetadataTransform {
         break;
       }
     }
-    log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
-        + key + "' in metadata.");
+    log.log(Level.FINE, "{0} find matching pattern for key {1} in metadata.",
+        new Object[] { (found ? "Did" : "Did not"), key });
     return found;
   }
 
@@ -215,10 +215,10 @@ public class RegexFilter implements MetadataTransform {
     if (params.containsKey(key)) {
       found = pattern.matcher(params.get(key)).find();
     } else if (log.isLoggable(Level.FINEST)) {
-      log.finest("No key `" + key + "' in params.");
+      log.log(Level.FINEST, "No key {0} in params.", key);
     }
-    log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
-        + key + "' in params.");
+    log.log(Level.FINE, "{0} find matching pattern for key {1} in params.",
+        new Object[] { (found ? "Did" : "Did not"), key });
     return found;
   }
 

--- a/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/RegexFilter.java
@@ -187,7 +187,7 @@ public class RegexFilter implements MetadataTransform {
   private boolean foundInMetadata(Metadata metadata) {
     boolean found = false;
     Set<String> values = metadata.getAllValues(key);
-    if (values.isEmpty()) {
+    if (values.isEmpty() && log.isLoggable(Level.FINEST)) {
       if (metadata.getKeys().contains(key)) {
         log.finest("No values for key `" + key + "' in metadata.");
       } else {
@@ -214,7 +214,7 @@ public class RegexFilter implements MetadataTransform {
     boolean found = false;
     if (params.containsKey(key)) {
       found = pattern.matcher(params.get(key)).find();
-    } else {
+    } else if (log.isLoggable(Level.FINEST)) {
       log.finest("No key `" + key + "' in params.");
     }
     log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"

--- a/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
@@ -31,6 +31,7 @@ import com.google.enterprise.adaptor.MetadataTransform;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -144,7 +145,7 @@ public class SkipDocumentFilter implements MetadataTransform {
   private boolean foundInMetadata(Metadata metadata) {
     boolean found = false;
     Set<String> values = metadata.getAllValues(propertyName);
-    if (values.isEmpty()) {
+    if (values.isEmpty() && log.isLoggable(Level.FINEST)) {
       if (metadata.getKeys().contains(propertyName)) {
         log.finest("No values for key `" + propertyName + "' in metadata.");
       } else {
@@ -171,7 +172,7 @@ public class SkipDocumentFilter implements MetadataTransform {
     boolean found = false;
     if (params.containsKey(propertyName)) {
       found = pattern.matcher(params.get(propertyName)).find();
-    } else {
+    } else if (log.isLoggable(Level.FINEST)) {
       log.finest("No key `" + propertyName + "' in params.");
     }
     log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"

--- a/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
@@ -147,9 +147,10 @@ public class SkipDocumentFilter implements MetadataTransform {
     Set<String> values = metadata.getAllValues(propertyName);
     if (values.isEmpty() && log.isLoggable(Level.FINEST)) {
       if (metadata.getKeys().contains(propertyName)) {
-        log.finest("No values for key `" + propertyName + "' in metadata.");
+        log.log(Level.FINEST, "No values for key {0} in metadata.",
+            propertyName);
       } else {
-        log.finest("No key `" + propertyName + "' in metadata.");
+        log.log(Level.FINEST, "No key {0} in metadata.", propertyName);
       }
     }
     for (String value : values) {
@@ -158,8 +159,8 @@ public class SkipDocumentFilter implements MetadataTransform {
         break;
       }
     }
-    log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
-        + propertyName + "' in metadata.");
+    log.log(Level.FINE, "{0} find matching pattern for key {1} in metadata.",
+        new Object[] { (found ? "Did" : "Did not"), propertyName });
     return found;
   }
 
@@ -172,11 +173,11 @@ public class SkipDocumentFilter implements MetadataTransform {
     boolean found = false;
     if (params.containsKey(propertyName)) {
       found = pattern.matcher(params.get(propertyName)).find();
-    } else if (log.isLoggable(Level.FINEST)) {
-      log.finest("No key `" + propertyName + "' in params.");
+    } else {
+      log.log(Level.FINEST, "No key {0} in params.", propertyName);
     }
-    log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
-        + propertyName + "' in params.");
+    log.log(Level.FINE, "{0} find matching pattern for key {1} in params.",
+        new Object[] { (found ? "Did" : "Did not"), propertyName });
     return found;
   }
 
@@ -210,21 +211,25 @@ public class SkipDocumentFilter implements MetadataTransform {
     // determine the Transmission Decision based on skipMatch
     if (skipOnMatch) {
       if (found) {
-        log.info("Skipping document " + docId + ", because we found a match in "
-            + corpora);
+        log.log(Level.INFO,
+            "Skipping document {0}, because we found a match in {1}.",
+            new Object[] { docId, corpora });
         params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,
             TransmissionDecision.DO_NOT_INDEX.toString());
       } else {
-        log.fine("No transmission decision for document " + docId
-             + ", because we did not find a match in " + corpora);
+        log.log(Level.FINE, "No transmission decision for document {0}, "
+            + "because we did not find a match in {1}.",
+            new Object[] { docId, corpora });
       }
     } else {
       if (found) {
-        log.fine("No transmission decision for document " + docId
-             + ", because we found a match in " + corpora);
+        log.log(Level.FINE, "No transmission decision for document {0}, "
+            + "because we found a match in {1}.",
+            new Object[] { docId, corpora });
       } else {
-        log.info("Skipping document " + docId + ", because we did not find a "
-            + "match in " + corpora);
+        log.log(Level.INFO,
+            "Skipping document {0}, because we did not find a match in {1}.",
+            new Object[] { docId, corpora });
         params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,
             TransmissionDecision.DO_NOT_INDEX.toString());
       }

--- a/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
@@ -30,6 +30,7 @@ import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.MetadataTransform;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -142,7 +143,15 @@ public class SkipDocumentFilter implements MetadataTransform {
    */
   private boolean foundInMetadata(Metadata metadata) {
     boolean found = false;
-    for (String value : metadata.getAllValues(propertyName)) {
+    Set<String> values = metadata.getAllValues(propertyName);
+    if (values.isEmpty()) {
+      if (metadata.getKeys().contains(propertyName)) {
+        log.fine("No values for key `" + propertyName + "' in metadata.");
+      } else {
+        log.fine("No key `" + propertyName + "' in metadata.");
+      }
+    }
+    for (String value : values) {
       if (pattern.matcher(value).find()) {
         found = true;
         break;
@@ -162,6 +171,8 @@ public class SkipDocumentFilter implements MetadataTransform {
     boolean found = false;
     if (params.containsKey(propertyName)) {
       found = pattern.matcher(params.get(propertyName)).find();
+    } else {
+      log.fine("No key `" + propertyName + "' in params.");
     }
     log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
         + propertyName + "' in params.");
@@ -203,13 +214,13 @@ public class SkipDocumentFilter implements MetadataTransform {
         params.put(MetadataTransform.KEY_TRANSMISSION_DECISION,
             TransmissionDecision.DO_NOT_INDEX.toString());
       } else {
-        log.fine("Not skipping document " + docId + ", because we did not find "
-            + "a match in " + corpora);
+        log.fine("No transmission decision for document " + docId
+             + ", because we did not find a match in " + corpora);
       }
     } else {
       if (found) {
-        log.fine("Not skipping document " + docId + ", because we found a match"
-            + " in " + corpora);
+        log.fine("No transmission decision for document " + docId
+             + ", because we found a match in " + corpora);
       } else {
         log.info("Skipping document " + docId + ", because we did not find a "
             + "match in " + corpora);

--- a/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/SkipDocumentFilter.java
@@ -146,9 +146,9 @@ public class SkipDocumentFilter implements MetadataTransform {
     Set<String> values = metadata.getAllValues(propertyName);
     if (values.isEmpty()) {
       if (metadata.getKeys().contains(propertyName)) {
-        log.fine("No values for key `" + propertyName + "' in metadata.");
+        log.finest("No values for key `" + propertyName + "' in metadata.");
       } else {
-        log.fine("No key `" + propertyName + "' in metadata.");
+        log.finest("No key `" + propertyName + "' in metadata.");
       }
     }
     for (String value : values) {
@@ -172,7 +172,7 @@ public class SkipDocumentFilter implements MetadataTransform {
     if (params.containsKey(propertyName)) {
       found = pattern.matcher(params.get(propertyName)).find();
     } else {
-      log.fine("No key `" + propertyName + "' in params.");
+      log.finest("No key `" + propertyName + "' in params.");
     }
     log.fine((found ? "Did" : "Did not") + " find matching pattern for key `"
         + propertyName + "' in params.");


### PR DESCRIPTION
Fix b/38359039 SkipDocumentFilter should log "No transmission decision"
instead of "Not Skipping"

Fix b/38356739 Param and metadata names are case-sensitive in transforms