### PR TITLE
Restore pristine Apache 2.0 license in LICENSE file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2011 Google Inc
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This reverts commit 66cab5d and renames LICENSE.txt to LICENSE,
following the open source licensing guidelines.