### PR TITLE
Change Config.validateTimeout from public to private.

### DIFF
--- a/src/com/google/enterprise/adaptor/Config.java
+++ b/src/com/google/enterprise/adaptor/Config.java
@@ -639,7 +639,7 @@ public class Config {
     return getValue("adaptor.fullListingSchedule");
   }
 
-  public long validateTimeout(String property) {
+  private long validateTimeout(String property) {
     String secondsAsString = getValue(property).trim();
     if ("0".equals(secondsAsString) || "".equals(secondsAsString)
         || secondsAsString.startsWith("-")) {


### PR DESCRIPTION
We didn't ponder making this method public. It has no javadoc, assumes
the units are seconds, and enforces a non-universal requirement for a
positive integer (zero and negative often mean wait forever). It was
public in the 4.1.3 release, but I removed it from the published
javadoc.