### PR TITLE
Fix a small bug in PrebuiltTransforms

### DIFF
--- a/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
@@ -355,7 +355,7 @@ public class PrebuiltTransforms {
     String prefix = "key";
     List<Key> keys = new LinkedList<Key>();
     for (Map.Entry<String, String> me : config.entrySet()) {
-      if (!me.getKey().startsWith(prefix)) {
+      if (!me.getKey().startsWith(prefix) || me.getKey().startsWith("keyset")) {
         continue;
       }
       String number = me.getKey().substring(prefix.length());


### PR DESCRIPTION
The getKeyList() method looks for config entries of the form
key#=value, where # is a number. However, it complains when
it encounters keyset entries, because "set" is not a number.