### PR TITLE
Extract DocumentRequest from DocumentHandler.

### DIFF
--- a/src/com/google/enterprise/adaptor/DocRequest.java
+++ b/src/com/google/enterprise/adaptor/DocRequest.java
@@ -35,10 +35,11 @@ public class DocRequest implements Request {
 
   /**
    * Constructs a request with a null access time that supports HTTP
-   * 204 responses. A null access times implies that the document has
+   * 204 responses. A null access time implies that the document has
    * never been crawled.
    *
    * @param docId the requested document ID
+   * @throws NullPointerException if {@code docId} is null
    */
   public DocRequest(DocId docId) {
     this(docId, null);
@@ -49,6 +50,7 @@ public class DocRequest implements Request {
    *
    * @param docId the requested document ID
    * @param lastAccessTime the last time the document was crawled
+   * @throws NullPointerException if {@code docId} is null
    */
   public DocRequest(DocId docId, Date lastAccessTime) {
     this(docId, lastAccessTime, true);
@@ -57,12 +59,17 @@ public class DocRequest implements Request {
   /** Constructs a request.
    *
    * @param docId the requested document ID
-   * @param lastAccessTime the last time the document was crawled
+   * @param lastAccessTime the last time the document was crawled;
+   *     {@code null} implies that the document has never been crawled
    * @param isNoContentSupported {@code true} if an HTTP 204 response
    *     is allowed, and {@code false} otherwise
+   * @throws NullPointerException if {@code docId} is null
    */
   public DocRequest(DocId docId, Date lastAccessTime,
       boolean isNoContentSupported) {
+    if (docId == null) {
+      throw new NullPointerException("DocId is null");
+    }
     this.docId = docId;
     this.lastAccessTime = lastAccessTime;
     this.isNoContentSupported = isNoContentSupported;

--- a/src/com/google/enterprise/adaptor/DocRequest.java
+++ b/src/com/google/enterprise/adaptor/DocRequest.java
@@ -1,0 +1,113 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor;
+
+import com.google.enterprise.adaptor.testing.UnsupportedRequest;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A complete implementation of {@link Request}.
+ *
+ * @see UnsupportedRequest
+ */
+public class DocRequest implements Request {
+  private static final Logger log
+      = Logger.getLogger(DocRequest.class.getName());
+
+  private final DocId docId;
+  private final Date lastAccessTime;
+  private final boolean isNoContentSupported;
+
+  /**
+   * Constructs a request with a null access time that supports HTTP
+   * 204 responses. A null access times implies that the document has
+   * never been crawled.
+   *
+   * @param docId the requested document ID
+   */
+  public DocRequest(DocId docId) {
+    this(docId, null);
+  }
+
+  /**
+   * Constructs a request that supports HTTP 204 responses.
+   *
+   * @param docId the requested document ID
+   * @param lastAccessTime the last time the document was crawled
+   */
+  public DocRequest(DocId docId, Date lastAccessTime) {
+    this(docId, lastAccessTime, true);
+  }
+
+  /** Constructs a request.
+   *
+   * @param docId the requested document ID
+   * @param lastAccessTime the last time the document was crawled
+   * @param isNoContentSupported {@code true} if an HTTP 204 response
+   *     is allowed, and {@code false} otherwise
+   */
+  public DocRequest(DocId docId, Date lastAccessTime,
+      boolean isNoContentSupported) {
+    this.docId = docId;
+    this.lastAccessTime = lastAccessTime;
+    this.isNoContentSupported = isNoContentSupported;
+  }
+
+  @Override
+  public String toString() {
+    return "Request(docId=" + docId + ",lastAccessTime=" + lastAccessTime + ")";
+  }
+
+  @Override
+  public DocId getDocId() {
+    return docId;
+  }
+
+  @Override
+  public Date getLastAccessTime() {
+    return lastAccessTime;
+  }
+
+  @Override
+  public boolean hasChangedSinceLastAccess(Date lastModified) {
+    if (lastAccessTime == null) {
+      return true;
+    }
+    if (lastModified == null) {
+      throw new NullPointerException("last modified is null");
+    }
+    // Adjust last modified date time by stripping milliseconds part as
+    // last access time will not have milliseconds part.
+    Date lastModifiedAdjusted
+        = new Date(1000 * (lastModified.getTime() / 1000));
+    log.log(Level.FINEST, "Last modified date time value {0} adjusted to {1}",
+        new Object[] {lastModified.getTime(), lastModifiedAdjusted.getTime()});
+    return lastAccessTime.before(lastModifiedAdjusted);
+  }
+
+  /**
+   * @return {@code true} if the docuemnt has not changed and we are
+   *     either talking to GSA version 7.4 or higher, or a web browser,
+   *     and {@code false} otherwise
+   */
+  // Note: for web browser startSending will convert 204 to 304
+  @Override
+  public boolean canRespondWithNoContent(Date lastModified) {
+    return isNoContentSupported && !hasChangedSinceLastAccess(lastModified);
+  }
+}

--- a/src/com/google/enterprise/adaptor/Request.java
+++ b/src/com/google/enterprise/adaptor/Request.java
@@ -25,7 +25,7 @@ import java.util.Date;
  *
  * <p>Avoid implementing this interface in adaptor unit tests because
  * new methods may be added in the future. Instead use
- * {@link UnsupportedRequest}, or use an automated mock
+ * {@link DocRequest}, {@link UnsupportedRequest}, or an automated mock
  * generator like Mockito or {@code java.lang.reflect.Proxy}.
  */
 public interface Request {

--- a/src/com/google/enterprise/adaptor/testing/UnsupportedRequest.java
+++ b/src/com/google/enterprise/adaptor/testing/UnsupportedRequest.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.adaptor.testing;
 
 import com.google.enterprise.adaptor.DocId;
+import com.google.enterprise.adaptor.DocRequest;
 import com.google.enterprise.adaptor.Request;
 
 import java.util.Date;
@@ -25,6 +26,8 @@ import java.util.Date;
  *
  * <p>This class is intended to be extended for unit testing, rather
  * than implementing the {@link Request} interface directly.
+ *
+ * @see DocRequest
  */
 public class UnsupportedRequest implements Request {
   /** @throws UnsupportedOperationException always */

--- a/test/com/google/enterprise/adaptor/DocRequestTest.java
+++ b/test/com/google/enterprise/adaptor/DocRequestTest.java
@@ -1,0 +1,92 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.adaptor;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Date;
+
+/**
+ * Tests for {@link DocRequest}.
+ */
+public class DocRequestTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testConstructor_nullDocId() {
+    thrown.expect(NullPointerException.class);
+    new DocRequest(null);
+  }
+
+  @Test
+  public void testConstructor_nullLastAccessTime() {
+    Request request = new DocRequest(new DocId("42"), null);
+    assertNull(request.getLastAccessTime());
+  }
+
+  @Test
+  public void testToString() {
+    // Epoch plus one day is 1970 in every time zone.
+    Request request =
+        new DocRequest(new DocId("xyggy"), new Date(DAYS.toMillis(1L)));
+    assertThat(request.toString(), containsString("xyggy"));
+    assertThat(request.toString(), containsString("1970"));
+  }
+
+  @Test
+  public void testHasChangedSinceLastAccess_nullLastModifiedTime() {
+    Request request = new DocRequest(new DocId("42"), new Date());
+    thrown.expect(NullPointerException.class);
+    request.hasChangedSinceLastAccess(null);
+  }
+
+  @Test
+  public void testHasChangedSinceLastAccess_nullLastAccessTime() {
+    Request request = new DocRequest(new DocId("42"), null);
+    assertTrue(request.hasChangedSinceLastAccess(null));
+  }
+
+  @Test
+  public void testCanRespondWithNoContent_supported() {
+    // Construct a request for an unchanged document.
+    DocId docId = new DocId("42");
+    Date lastAccessTime = new Date();
+    Date lastModifiedTime = new Date(0L);
+
+    Request request = new DocRequest(docId, lastAccessTime, true);
+    assertTrue(request.canRespondWithNoContent(lastModifiedTime));
+  }
+
+  @Test
+  public void testCanRespondWithNoContent_unsupported() {
+    // Construct a request for an unchanged document.
+    DocId docId = new DocId("42");
+    Date lastAccessTime = new Date();
+    Date lastModifiedTime = new Date(0L);
+
+    Request request = new DocRequest(docId, lastAccessTime, false);
+    assertFalse(request.canRespondWithNoContent(lastModifiedTime));
+  }
+}

--- a/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/CommandLineAdaptorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.enterprise.adaptor.AuthnIdentity;
 import com.google.enterprise.adaptor.AuthzStatus;
 import com.google.enterprise.adaptor.DocId;
+import com.google.enterprise.adaptor.DocRequest;
 import com.google.enterprise.adaptor.GroupPrincipal;
 import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.Request;
@@ -238,39 +239,6 @@ public class CommandLineAdaptorTest {
     }
   }
 
-  private static class ContentsRequestTestMock implements Request {
-    private DocId docId;
-    private Date lastCrawled;
-
-    public ContentsRequestTestMock(DocId docId) {
-      this.docId = docId;
-    }
-
-    @Override
-    public boolean hasChangedSinceLastAccess(Date lastModified) {
-      Date date = getLastAccessTime();
-      if (date == null) {
-        return true;
-      }
-      return date.before(lastModified);
-    }
-
-    @Override
-    public Date getLastAccessTime() {
-      return lastCrawled;
-    }
-
-    @Override
-    public DocId getDocId() {
-      return docId;
-    }
-    
-    @Override
-    public boolean canRespondWithNoContent(Date lastModified) {
-      return !hasChangedSinceLastAccess(lastModified);
-    }
-  }
-
   @Test
   public void testListerAndRetriever() throws Exception {
     CommandLineAdaptor adaptor = new CommandLineAdaptorTestMock();
@@ -322,8 +290,7 @@ public class CommandLineAdaptorTest {
 
     // Test retriever
     for (DocId docId : idList) {
-
-      ContentsRequestTestMock request = new ContentsRequestTestMock(docId);
+      Request request = new DocRequest(docId);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       RecordingResponse response = new RecordingResponse(baos);
 


### PR DESCRIPTION
This is intended as a replacement for the various mock Request
implementations in the library and connectors, as well as remaining
the production implementation.

There are a few modest changes to the class:

* Rename to DocRequest for consistency with public names.
* Avoid using HttpExchange in the fields and constructor args.
* Reorder the methods.
* Simplify canRespondWithNoContent.