### PR TITLE
Trigger more javac lint warnings and fix them.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -125,8 +125,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
       target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
-      <compilerarg value="-Xlint:deprecation"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <exclude name="${adaptor.pkg.dir}/examples/**"/>
@@ -138,7 +137,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="examples.build.classpath"/>
       <include name="${adaptor.pkg.dir}/examples/**"/>
@@ -149,7 +148,7 @@
     <javac srcdir="${lib.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="true" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="junit.classpath"/>
       <include name="JUnitLogFixFormatter.java"/>
@@ -159,7 +158,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${build-src.dir}"/>
@@ -172,7 +171,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="examples.build.classpath"/>
       <classpath location="${build-src.dir}"/>
@@ -184,8 +183,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
-      <compilerarg value="-Xlint:deprecation"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${lib.dir}/commons-fileupload-1.3.jar"/>
@@ -196,7 +194,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg value="-Xlint:unchecked"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${build-src.dir}"/>

--- a/src/com/google/enterprise/adaptor/Acl.java
+++ b/src/com/google/enterprise/adaptor/Acl.java
@@ -127,6 +127,11 @@ public class Acl {
     public boolean equals(Object o) {
       return o instanceof CaseInsensitiveCmp;
     }
+
+    @Override
+    public int hashCode() {
+      return CaseInsensitiveCmp.class.hashCode();
+    }
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/HttpClientAdapter.java
+++ b/src/com/google/enterprise/adaptor/HttpClientAdapter.java
@@ -86,7 +86,7 @@ class HttpClientAdapter implements HttpClientInterface {
 
     @Override
     public void setFollowRedirects(boolean followRedirects) {
-      conn.setFollowRedirects(followRedirects);
+      HttpURLConnection.setFollowRedirects(followRedirects);
     }
 
     @Override

--- a/src/com/google/enterprise/adaptor/Watchdog.java
+++ b/src/com/google/enterprise/adaptor/Watchdog.java
@@ -97,7 +97,7 @@ class Watchdog {
         // Interrupter has interrupted this thread.
         // Clear the interrupt, if not already cleared, since we don't want to
         // interrupt this thread any further.
-        thread.interrupted();
+        Thread.interrupted();
       }
     }
   }

--- a/test/com/google/enterprise/adaptor/ExceptionHandlersTest.java
+++ b/test/com/google/enterprise/adaptor/ExceptionHandlersTest.java
@@ -38,6 +38,6 @@ public class ExceptionHandlersTest {
     Thread.currentThread().interrupt();
     assertFalse(handler.handleException(new RuntimeException(), 1));
     // Clear flag
-    Thread.currentThread().interrupted();
+    Thread.interrupted();
   }
 }

--- a/test/com/google/enterprise/adaptor/MockHttpExchange.java
+++ b/test/com/google/enterprise/adaptor/MockHttpExchange.java
@@ -218,7 +218,7 @@ public class MockHttpExchange extends HttpExchange {
   }
 
   public byte[] getResponseBytes() {
-    return ((ByteArrayOutputStream) responseBodyOrig).toByteArray();
+    return responseBodyOrig.toByteArray();
   }
 
   private static class ClosingFilterOutputStream

--- a/test/com/google/enterprise/adaptor/RpcHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/RpcHandlerTest.java
@@ -56,7 +56,7 @@ public class RpcHandlerTest {
     MockHttpExchange ex = makeExchange("POST", "/r", "/r");
     handler.handle(ex);
     assertEquals(409, ex.getResponseCode());
-    xsrfToken = (String) ex.getResponseHeaders().getFirst(
+    xsrfToken = ex.getResponseHeaders().getFirst(
         RpcHandler.XSRF_TOKEN_HEADER_NAME);
     assertNotNull(xsrfToken);
     sessionId = clientStore.retrieve(ex);


### PR DESCRIPTION
* path warnings are often triggered by Class-Path entries in
  third-party JAR files.
* serial warnings are triggered by many things, and we don't
  serialize anything.
* rawtypes warnings are triggered by avoiding generics, e.g.,
  using List instead of List<?>.