### PR TITLE
Java 9 compatibility.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,11 @@
   <property name="adaptor.args" value=""/>
   <property name="cobertura.dir" value="${basedir}/../cobertura/"/>
 
+  <!-- Use add-modules with Java 9 and higher. -->
+  <condition property="java.modules" value="" else="--add-modules java.se.ee">
+    <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
+  </condition>
+
   <path id="adaptorlib.build.classpath">
     <fileset dir="${lib.dir}">
       <include name="json_simple-1.1.jar"/>
@@ -140,7 +145,9 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
       target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
+      <compilerarg value="-Xlint"/>
+      <compilerarg
+          line="-Xlint:-path -Xlint:-serial -Xlint:-rawtypes -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <exclude name="${adaptor.pkg.dir}/examples/**"/>
@@ -152,7 +159,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="examples.build.classpath"/>
       <include name="${adaptor.pkg.dir}/examples/**"/>
@@ -163,7 +170,7 @@
     <javac srcdir="${lib.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="true" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="junit.classpath"/>
       <include name="JUnitLogFixFormatter.java"/>
@@ -173,7 +180,9 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
+      <compilerarg value="-Xlint"/>
+      <compilerarg
+          line="-Xlint:-path -Xlint:-serial -Xlint:-rawtypes -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${build-src.dir}"/>
@@ -186,7 +195,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="examples.build.classpath"/>
       <classpath location="${build-src.dir}"/>
@@ -198,7 +207,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${lib.dir}/commons-fileupload-1.3.jar"/>
@@ -209,7 +218,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${build-src.dir}"/>
@@ -417,6 +426,7 @@
 
   <target name="run" depends="build" description="Run default adaptor">
     <java classpath="${build-src.dir}" fork="true" classname="${adaptor.class}">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptorlib.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>
@@ -433,6 +443,7 @@
   <target name="groups_writer" depends="build" description="Run groups writer">
     <java classpath="${build-src.dir}" fork="true"
       classname="${adaptor.pkg.name}.examples.GroupDefinitionsWriter">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptorlib.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>
@@ -450,6 +461,7 @@
       description="Run groups from csv">
     <java classpath="${build-src.dir}" fork="true"
       classname="${adaptor.pkg.name}.examples.GroupDefinitionsFromCsv">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptorlib.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>
@@ -467,6 +479,7 @@
       description="Run groups scale tester">
     <java classpath="${build-src.dir}" fork="true"
       classname="${adaptor.pkg.name}.examples.GroupDefinitionsScaleTester">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptorlib.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>
@@ -496,6 +509,7 @@
   <target name="test" depends="build" description="Run JUnit tests">
     <junit printsummary="yes" haltonfailure="yes" forkmode="once" fork="true"
       dir="${basedir}" maxmemory="512m">
+      <jvmarg line="${java.modules}"/>
       <sysproperty key="net.sourceforge.cobertura.datafile"
         file="${build-instrument.dir}/cobertura.ser"/>
       <classpath refid="adaptorlib.run.classpath"/>

--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,8 @@
   <property name="cobertura.dir" value="${basedir}/../cobertura/"/>
 
   <!-- Use add-modules with Java 9 and higher. -->
-  <condition property="java.modules" value="" else="--add-modules java.se.ee">
+  <condition property="java.modules"
+      value="" else="--add-modules java.xml.bind">
     <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
   </condition>
 
@@ -414,6 +415,7 @@
       <link href="http://download.oracle.com/javase/6/docs/jre/api/net/httpserver/spec/"/>
       <link href="http://download.oracle.com/javase/6/docs/api/"/>
       <link href="http://commons.apache.org/proper/commons-daemon/apidocs/"/>
+      <arg line="${java.modules}"/>
       <arg value="-quiet"/>
       <arg value="-notimestamp"/>
     </javadoc>

--- a/src/com/google/enterprise/adaptor/Daemon.java
+++ b/src/com/google/enterprise/adaptor/Daemon.java
@@ -74,7 +74,8 @@ public class Daemon implements org.apache.commons.daemon.Daemon {
           "Missing argument: adaptor class name");
     }
     Adaptor adaptor
-        = Class.forName(args[0]).asSubclass(Adaptor.class).newInstance();
+        = Class.forName(args[0]).asSubclass(Adaptor.class)
+            .getDeclaredConstructor().newInstance();
     args = Arrays.copyOfRange(args, 1, args.length);
 
     app = Application.daemonMain(adaptor, args);

--- a/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
@@ -62,7 +62,7 @@ public class PrebuiltTransforms {
   // Returns overwrite config as a Boolean, or null if overwrite is unspecified.
   private static Boolean getOverwrite(Map<String, String> cfg) {
     String overwrite = getTrimmedValue(cfg, "overwrite");
-    return (overwrite == null) ? null : new Boolean(overwrite);
+    return (overwrite == null) ? null : Boolean.valueOf(overwrite);
   }
 
   /**

--- a/src/com/google/enterprise/adaptor/secmgr/config/ConfigSingleton.java
+++ b/src/com/google/enterprise/adaptor/secmgr/config/ConfigSingleton.java
@@ -14,13 +14,10 @@
 
 package com.google.enterprise.adaptor.secmgr.config;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.util.Observable;
-import java.util.Observer;
 import java.util.logging.Logger;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -33,46 +30,9 @@ import javax.annotation.concurrent.ThreadSafe;
 public class ConfigSingleton {
   private static final Logger LOGGER = Logger.getLogger(ConfigSingleton.class.getName());
 
-  private static ConfigSingleton instance;
   @GuardedBy("class") private static Gson gson;
-  private static final LocalObservable observable = new LocalObservable();
-
-  private static final class LocalObservable extends Observable {
-    @Override
-    protected void setChanged() {
-      super.setChanged();
-    }
-  }
 
   private ConfigSingleton() {
-    resetInternal();
-  }
-
-  @VisibleForTesting
-  public static synchronized void reset() {
-    instance.resetInternal();
-  }
-
-  private synchronized void resetInternal() {
-  }
-
-  /**
-   * Adds an observer that's notified of config changes.
-   */
-  public static void addObserver(Observer observer) {
-    observable.addObserver(observer);
-  }
-
-  /**
-   * Gets an observable that's notified of config changes.
-   */
-  public static Observable getObservable() {
-    return observable;
-  }
-
-  static void setChanged() {
-    observable.setChanged();
-    observable.notifyObservers();
   }
 
   public static synchronized void setGsonRegistrations(GsonRegistrations registrations) {

--- a/src/overview.html
+++ b/src/overview.html
@@ -24,7 +24,7 @@
       and scroll down to <b>List of Trusted IP Addresses</b>. Add the IP address
       for the adaptor to the list.</p>
     <li>Add the URLs provided by the adaptor to the <b>Follow Patterns</b> on the GSA.
-      <p>In the Admin console, go to <b>Content Sources &gt; Web Crawl &gt Start and
+      <p>In the Admin console, go to <b>Content Sources &gt; Web Crawl &gt; Start and
       Block URLs </b>, and scroll down to <b>Follow Patterns</b>. Add an entry like
       {@code hostname:port/} where {@code hostname} is the hostname of the machine
       that hosts the adaptor and {@code port} defaults to 5678 (read on to 
@@ -152,7 +152,7 @@ feed.name=mydocfeedtogsa</pre>
     one. Setting up security is required before users can access non-public
     documents directly from the adaptor.
 
-  <h3>Creating Self-Signed Certificates</h3>
+  <h2>Creating Self-Signed Certificates</h2>
   <p>In the GSA's Admin Console, go to <b>Administration &gt; SSL Settings</b>.
     Under the <b>Create a New SSL Certificate</b> heading change <b>Host
     Name</b> to GSA's hostname written exactly as the adaptor will use.
@@ -211,7 +211,7 @@ feed.name=mydocfeedtogsa</pre>
   <pre>keytool -importcert -keystore cacerts.jks -storepass changeit -file adaptor.crt -alias adaptor</pre>
   <p>Answer "yes" to "Trust this certificate?"
 
-  <h3>Exchanging Certificates</h3>
+  <h2>Exchanging Certificates</h2>
   <p>To allow the adaptor to trust the GSA, execute:
   <pre>keytool -importcert -keystore cacerts.jks -storepass changeit -file gsa.crt -alias gsa</pre>
   <p>Answer "yes" to "Trust this certificate?"
@@ -223,7 +223,7 @@ feed.name=mydocfeedtogsa</pre>
     Choose "adaptor.crt" in the adaptor's directory and click <b>Save
     Settings</b>.
 
-  <h3>Flipping the Switch</h3>
+  <h2>Flipping the Switch</h2>
   <p>Now that everything is prepared, you can flip the security switch with the
     adaptor by adding a line to your <code>adaptor-config.properties</code>:
   <pre>server.secure=true</pre>
@@ -243,7 +243,7 @@ feed.name=mydocfeedtogsa</pre>
     com.google.enterprise.adaptor.examples.AdaptorWithCrawlTimeMetadataTemplate
   </pre>
 
-  <h3>Enable Stricter Security (optional)</h3>
+  <h2>Enable Stricter Security (optional)</h2>
   <p>There are additional security options you can control on the GSA.
     You may want to try running an adaptor with server.secure set before
     enabling these stricter features.

--- a/test/com/google/enterprise/adaptor/GsaFeedFileMakerTest.java
+++ b/test/com/google/enterprise/adaptor/GsaFeedFileMakerTest.java
@@ -54,7 +54,7 @@ public class GsaFeedFileMakerTest {
         + "</gsafeed>\n";
     String xml = meker.makeMetadataAndUrlXml("t3sT",
         new ArrayList<DocIdPusher.Record>());
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -92,7 +92,7 @@ public class GsaFeedFileMakerTest {
     ids.add(new DocIdPusher.Record.Builder(new DocId("empty-not-null-metadata"))
         .setMetadata(new Metadata()).build());
     String xml = meker.makeMetadataAndUrlXml("t3sT", ids);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -151,7 +151,7 @@ public class GsaFeedFileMakerTest {
         .setDeleteFromIndex(true).build());
 
     String xml = meker.makeMetadataAndUrlXml("t3sT", ids);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -214,7 +214,7 @@ public class GsaFeedFileMakerTest {
         .build()));
 
     String xml = meker.makeMetadataAndUrlXml("test", acls);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -247,7 +247,7 @@ public class GsaFeedFileMakerTest {
         new AclTransform.MatchData(null, "pu2", null, null))));
     meker = new GsaFeedFileMaker(encoder, aclTransform);
     String xml = meker.makeMetadataAndUrlXml("test", acls);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -283,7 +283,7 @@ public class GsaFeedFileMakerTest {
     meker = new GsaFeedFileMaker(encoder, aclTransform,
         true /* 6.14 workaround */, false);
     String xml = meker.makeMetadataAndUrlXml("test", records);
-    xml = xml.replace("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -310,7 +310,7 @@ public class GsaFeedFileMakerTest {
     meker = new GsaFeedFileMaker(encoder, aclTransform, false,
         true /* 7.0 workaround */);
     String xml = meker.makeMetadataAndUrlXml("test", records);
-    xml = xml.replace("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -336,7 +336,7 @@ public class GsaFeedFileMakerTest {
           new Acl.Builder()
             .setInheritFrom(new DocId("docid2"), "generated").build());
     String xml = meker.makeMetadataAndUrlXml("test", Arrays.asList(acl));
-    xml = xml.replace("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -350,7 +350,7 @@ public class GsaFeedFileMakerTest {
         + "</xmlgroups>\n";
     String xml = meker.makeGroupDefinitionsXml(
         new TreeMap<GroupPrincipal, List<Principal>>().entrySet(), true);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -378,7 +378,7 @@ public class GsaFeedFileMakerTest {
     members.add(new UserPrincipal("MacLeod\\Duncan"));
     groupDefs.put(new GroupPrincipal("immortals"), members);
     String xml = meker.makeGroupDefinitionsXml(groupDefs.entrySet(), false);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -431,7 +431,7 @@ public class GsaFeedFileMakerTest {
     members2.add(new UserPrincipal("plump"));
     groupDefs.put(new GroupPrincipal("sounds"), members2);
     String xml = meker.makeGroupDefinitionsXml(groupDefs.entrySet(), false);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -465,7 +465,7 @@ public class GsaFeedFileMakerTest {
     members.add(new GroupPrincipal("badguys", "3vil"));
     groupDefs.put(new GroupPrincipal("immortals"), members);
     String xml = meker.makeGroupDefinitionsXml(groupDefs.entrySet(), true);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -499,7 +499,7 @@ public class GsaFeedFileMakerTest {
           new AclTransform.MatchData(null, "Clan MacLeod", null, null))));
     meker = new GsaFeedFileMaker(encoder, aclTransform);
     String xml = meker.makeGroupDefinitionsXml(groupDefs.entrySet(), false);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -585,7 +585,7 @@ public class GsaFeedFileMakerTest {
         .setDeleteFromIndex(true).build());
 
     String xml = lclMeker.makeMetadataAndUrlXml("t3sT", ids);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -671,7 +671,7 @@ public class GsaFeedFileMakerTest {
         .setDeleteFromIndex(true).build());
 
     String xml = lclMeker.makeMetadataAndUrlXml("t3sT", ids);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 
@@ -711,7 +711,7 @@ public class GsaFeedFileMakerTest {
 
     ArrayList<DocIdPusher.Record> ids = new ArrayList<DocIdPusher.Record>();
     String xml = lclMeker.makeMetadataAndUrlXml("t3sT", ids);
-    xml = xml.replaceAll("\r\n", "\n");
+    xml = xml.replaceAll("\r?\n\\s*", "\n");
     assertEquals(golden, xml);
   }
 }

--- a/test/com/google/enterprise/adaptor/MockSslSession.java
+++ b/test/com/google/enterprise/adaptor/MockSslSession.java
@@ -20,7 +20,6 @@ import java.security.cert.Certificate;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
-import javax.security.cert.X509Certificate;
 
 /**
  * Mock {@link SSLSession} for testing.
@@ -72,8 +71,9 @@ public class MockSslSession implements SSLSession {
     throw new UnsupportedOperationException();
   }
 
+  @Deprecated
   @Override
-  public X509Certificate[] getPeerCertificateChain() {
+  public javax.security.cert.X509Certificate[] getPeerCertificateChain() {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
Deprecated features:

* javac -source and -target value of 1.6 (suppress with -Xlint:-options)
* Class.newInstance (use Constructor.newInstance)
* Object.finalize (refactor DbAdaptorTemplate to match DB connector)
* new Boolean(String) (use Boolean.valueOf(String))
* java.util.Observable and java.util.Observer (delete unused code)
* javax.security.cert.X509Certificate (use @Deprecated and avoid import)

Java EE features:

* Add --add-modules java.se.ee; also requires Ant 1.9.4 or later

Behaviorial changes:

* XML whitespace changes (delete leading whitespace in tests)