### PR TITLE
Remove the suppression of rawtypes warnings.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -140,7 +140,7 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
       target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <exclude name="${adaptor.pkg.dir}/examples/**"/>
@@ -173,7 +173,7 @@
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
            includeantruntime="false" encoding="utf-8"
            target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-rawtypes"/>
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath location="${build-src.dir}"/>

--- a/src/com/google/enterprise/adaptor/CronScheduler.java
+++ b/src/com/google/enterprise/adaptor/CronScheduler.java
@@ -72,7 +72,7 @@ class CronScheduler {
     if (!(future instanceof CronFuture)) {
       throw new IllegalArgumentException("Provided future is not a CronFuture");
     }
-    CronFuture cronFuture = (CronFuture) future;
+    CronFuture<?> cronFuture = (CronFuture) future;
     CronPattern compiledPattern = CronPattern.create(pattern);
     cronFuture.getCronFilterRunnable().setPattern(compiledPattern);
   }

--- a/src/com/google/enterprise/adaptor/Dashboard.java
+++ b/src/com/google/enterprise/adaptor/Dashboard.java
@@ -119,14 +119,14 @@ class Dashboard {
 
   private class StartFeedPushRpcMethod implements RpcHandler.RpcMethod {
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       return gsaCommHandler.checkAndScheduleImmediatePushOfDocIds();
     }
   }
   
   private class StopAdaptorRpcMethod implements RpcHandler.RpcMethod {
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       Thread thread = new Thread(shutdownHook);
       thread.start();
       // return true as an indication that server accepted request to stop
@@ -138,7 +138,7 @@ class Dashboard {
       implements RpcHandler.RpcMethod {
 
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       return gsaCommHandler.checkAndScheduleIncrementalPushOfDocIds();
     }
   }
@@ -156,7 +156,7 @@ class Dashboard {
     }
 
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       return circularLog.writeOut();
     }
 
@@ -174,7 +174,7 @@ class Dashboard {
     }
 
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       TreeMap<String, String> configMap = new TreeMap<String, String>();
       for (String key : config.getAllKeys()) {
         configMap.put(key, config.getValue(key));
@@ -201,7 +201,7 @@ class Dashboard {
     }
 
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       Map<StatusSource, Status> statuses = retrieveStatuses();
       List<Object> flatStatuses = new ArrayList<Object>(statuses.size());
       // TODO(ejona): choose locale based on Accept-Languages.
@@ -228,7 +228,7 @@ class Dashboard {
      * Requires two parameters: string to encode and security level.
      */
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       if (request.size() < 2) {
         throw new IllegalArgumentException("Required parameters are: string to "
             + "encode and security level");

--- a/src/com/google/enterprise/adaptor/Principal.java
+++ b/src/com/google/enterprise/adaptor/Principal.java
@@ -166,7 +166,7 @@ public abstract class Principal implements Comparable<Principal> {
    * objects: {@code principal.equals(principal.parse().toPrincipal())} is
    * always {@code true}.
    */
-  static class ParsedPrincipal<T extends Principal> {
+  static class ParsedPrincipal {
     public final boolean isGroup;
     public final String plainName;
     public final String domain;

--- a/src/com/google/enterprise/adaptor/RpcHandler.java
+++ b/src/com/google/enterprise/adaptor/RpcHandler.java
@@ -116,10 +116,10 @@ class RpcHandler implements HttpHandler {
       return;
     }
     String method;
-    List params;
+    List<?> params;
     Object id;
     try {
-      Map request = (Map) requestObj;
+      Map<?, ?> request = (Map) requestObj;
       method = (String) request.get("method");
       params = (List) request.get("params");
       id = request.get("id");
@@ -174,6 +174,6 @@ class RpcHandler implements HttpHandler {
      *
      * @throws Exception when something goes wrong
      */
-    public Object run(List request) throws Exception;
+    public Object run(List<?> request) throws Exception;
   }
 }

--- a/src/com/google/enterprise/adaptor/SamlIdentityProvider.java
+++ b/src/com/google/enterprise/adaptor/SamlIdentityProvider.java
@@ -313,6 +313,7 @@ class SamlIdentityProvider {
       this.requestUri = requestUri.toASCIIString();
     }
 
+    @SuppressWarnings("rawtypes") // The super class does not use generics.
     @Override
     protected String getActualReceiverEndpointURI(
         SAMLMessageContext messageContext) {

--- a/src/com/google/enterprise/adaptor/StatRpcMethod.java
+++ b/src/com/google/enterprise/adaptor/StatRpcMethod.java
@@ -46,7 +46,7 @@ class StatRpcMethod implements RpcHandler.RpcMethod {
     this.isIncrementalPushSupported = isIncrementalPushSupported;
     this.configFile = configFile;
 
-    Class adaptorClass = adaptor.getClass();
+    Class<?> adaptorClass = adaptor.getClass();
     if (adaptorClass.getPackage() != null) {
       adaptorVersion = adaptorClass.getPackage().getImplementationVersion();
       adaptorType = adaptorClass.getPackage().getImplementationTitle();
@@ -57,7 +57,7 @@ class StatRpcMethod implements RpcHandler.RpcMethod {
   }
 
   @Override
-  public Object run(List request) {
+  public Object run(List<?> request) {
     // TODO(ejona): choose locale based on Accept-Languages.
     Locale locale = Locale.ENGLISH;
 

--- a/test/com/google/enterprise/adaptor/DashboardTest.java
+++ b/test/com/google/enterprise/adaptor/DashboardTest.java
@@ -66,7 +66,7 @@ public class DashboardTest {
     config.setKey("gsa.characterEncoding", "UTF-8");
     config.setKey("server.hostname", "localhost");
     Dashboard.ConfigRpcMethod method = new Dashboard.ConfigRpcMethod(config);
-    Map map = (Map) method.run(null);
+    Map<?, ?> map = (Map) method.run(null);
     assertEquals(golden, map);
   }
 
@@ -86,7 +86,7 @@ public class DashboardTest {
     MockStatusSource source = new MockStatusSource("mock", status);
     sources.add(source);
     Dashboard.StatusRpcMethod method = new Dashboard.StatusRpcMethod(sources);
-    List list = (List) method.run(null);
+    List<?> list = (List) method.run(null);
     assertEquals(golden, list);
   }
 

--- a/test/com/google/enterprise/adaptor/DocIdSenderTest.java
+++ b/test/com/google/enterprise/adaptor/DocIdSenderTest.java
@@ -858,16 +858,17 @@ public class DocIdSenderTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testExpectedResultEmptyGroups() {
-    assertEquals(ImmutableList.<List>of(ImmutableList.<Map.Entry>of()),
-                 expectedResult(2, emptyGroups()));
+    assertEquals(ImmutableList.of(
+          ImmutableList.<Map.Entry<GroupPrincipal, Collection<Principal>>>of()),
+        expectedResult(2, emptyGroups()));
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void testExpectedResultSingleBatch() {
     assertEquals(
-        ImmutableList.<List>of(
-            ImmutableList.<Map.Entry>of(
+        ImmutableList.of(
+            ImmutableList.of(
                 mapEntry("g1", "u1"),
                 mapEntry("g2", "u2"),
                 mapEntry("g3", "u3"))),
@@ -885,8 +886,8 @@ public class DocIdSenderTest {
   @SuppressWarnings("unchecked")
   public void testExpectedResultExactBatch() {
     assertEquals(
-        ImmutableList.<List>of(
-            ImmutableList.<Map.Entry>of(
+        ImmutableList.of(
+            ImmutableList.of(
                 mapEntry("g1", "u1"),
                 mapEntry("g2", "u2"))),
         expectedResult(2,
@@ -901,11 +902,11 @@ public class DocIdSenderTest {
   @SuppressWarnings("unchecked")
   public void testExpectedResultMultipleBatchs() {
     assertEquals(
-        ImmutableList.<List>of(
-            ImmutableList.<Map.Entry>of(
+        ImmutableList.of(
+            ImmutableList.of(
                 mapEntry("g1", "u1"),
                 mapEntry("g2", "u2")),
-            ImmutableList.<Map.Entry>of(
+            ImmutableList.of(
                 mapEntry("g3", "u3"))),
         expectedResult(2,
             ImmutableMap.<GroupPrincipal, Collection<Principal>>of(
@@ -921,13 +922,13 @@ public class DocIdSenderTest {
   @SuppressWarnings("unchecked")
   public void testExpectedResultMultipleGroupMaps() {
     assertEquals(
-        ImmutableList.<List>of(
-            ImmutableList.<Map.Entry>of(
+        ImmutableList.of(
+            ImmutableList.of(
                 mapEntry("g1", "u1"),
                 mapEntry("g2", "u2")),
-            ImmutableList.<Map.Entry>of(
+            ImmutableList.of(
                 mapEntry("g3", "u3")),
-            ImmutableList.<Map.Entry>of(
+            ImmutableList.of(
                 mapEntry("g4", "u4"),
                 mapEntry("g5", "u5"))),
         expectedResult(2,

--- a/test/com/google/enterprise/adaptor/DownloadDumpHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/DownloadDumpHandlerTest.java
@@ -176,7 +176,7 @@ public class DownloadDumpHandlerTest {
 
       /** generate neither versionStats nor simpleStats maps */
       @Override
-      public Object run(List request) {
+      public Object run(List<?> request) {
         Map<String, Object> results = new HashMap<String, Object>();
         Map<String, Object> otherStats = new HashMap<String, Object>();
         otherStats.put("someBooleanValue", false);
@@ -218,7 +218,7 @@ public class DownloadDumpHandlerTest {
 
       /** generate neither versionStats nor simpleStats maps */
       @Override
-      public Object run(List request) {
+      public Object run(List<?> request) {
         Map<String, Object> results = new HashMap<String, Object>();
         Map<String, Object> simpleStats = new TreeMap<String, Object>();
         // keys get sorted into alphabetic order in golden map below
@@ -320,7 +320,7 @@ public class DownloadDumpHandlerTest {
     }
 
     @Override
-    public Object run(List request) {
+    public Object run(List<?> request) {
       Map<String, Object> golden = new HashMap<String, Object>();
       Map<String, Object> simpleStats = new HashMap<String, Object>();
       simpleStats.put("isIncrementalSupported", false);

--- a/test/com/google/enterprise/adaptor/RpcHandlerTest.java
+++ b/test/com/google/enterprise/adaptor/RpcHandlerTest.java
@@ -132,7 +132,7 @@ public class RpcHandlerTest {
   public void testValidCallWithResponse() throws Exception {
     handler.registerRpcMethod("someName", new RpcHandler.RpcMethod() {
       @Override
-      public Object run(List request) throws Exception {
+      public Object run(List<?> request) throws Exception {
         if (request.size() == 1 && request.get(0).equals("input")) {
           return "some response";
         } else {
@@ -167,7 +167,7 @@ public class RpcHandlerTest {
   public void testValidCallWithBrokenResponse() throws Exception {
     handler.registerRpcMethod("someName", new RpcHandler.RpcMethod() {
       @Override
-      public Object run(List request) throws Exception {
+      public Object run(List<?> request) throws Exception {
         return null;
       }
     });
@@ -186,7 +186,7 @@ public class RpcHandlerTest {
   public void testExceptionWithMessage() throws Exception {
     handler.registerRpcMethod("someName", new RpcHandler.RpcMethod() {
       @Override
-      public Object run(List request) throws Exception {
+      public Object run(List<?> request) throws Exception {
         throw new RuntimeException("some error");
       }
     });
@@ -205,7 +205,7 @@ public class RpcHandlerTest {
   public void testExceptionWithoutMessage() throws Exception {
     handler.registerRpcMethod("someName", new RpcHandler.RpcMethod() {
       @Override
-      public Object run(List request) throws Exception {
+      public Object run(List<?> request) throws Exception {
         throw new RuntimeException();
       }
     });
@@ -252,7 +252,7 @@ public class RpcHandlerTest {
 
   private static class ErroringRpcMethod implements RpcHandler.RpcMethod {
     @Override
-    public Object run(List request) throws Exception {
+    public Object run(List<?> request) throws Exception {
       throw new RuntimeException();
     }
   }

--- a/test/com/google/enterprise/adaptor/SamlServiceProviderTest.java
+++ b/test/com/google/enterprise/adaptor/SamlServiceProviderTest.java
@@ -1002,6 +1002,7 @@ public class SamlServiceProviderTest {
   }
 
   private static class RedirectDecoder extends HTTPRedirectDeflateDecoder {
+    @SuppressWarnings("rawtypes") // The super class does not use generics.
     @Override
     protected String getActualReceiverEndpointURI(
         SAMLMessageContext messageContext) {


### PR DESCRIPTION
There were five cases:

* Code that expected generic Objects (use a wildcard type parameter)
* Unnecessary type parameters on a class (remove parameterization)
* Unnecessary type parameters on a method (use inferred type)
* Incomplete type parameters on a method (add full type parameters)
* Overrides of API methods that do not use generics (suppress warning)