### PR TITLE
Use cleanup feed instead of empty full feed for groups

### DIFF
--- a/src/com/google/enterprise/adaptor/DocIdPusher.java
+++ b/src/com/google/enterprise/adaptor/DocIdPusher.java
@@ -41,9 +41,10 @@ public interface DocIdPusher {
   /**
    * FeedType used for group definition pushes.
    *
-   * GSA 7.4.0 added support for full feeds of group definitions. A {@code FULL}
-   * feed replaces all groups from a given data source. An {@code INCREMENTAL}
-   * feed augments or updates existing group definitions for a given data source.
+   * GSA 7.4.0 added support for full feeds of group definitions.
+   * A {@code REPLACE} feed replaces all groups from a given data source.
+   * An {@code INCREMENTAL} feed augments or updates existing group definitions
+   * for a given data source.
    * When feeding GSAs earlier than 7.4.0, {@code INCREMENTAL} feeds are always
    * used. {@code INCREMENTAL} is the default FeedType for the overloaded
    * {@code pushGroupDefinitions} methods that do specify a FeedType.
@@ -51,7 +52,7 @@ public interface DocIdPusher {
    * @since 4.1.4
    */
   public static enum FeedType {
-    FULL, INCREMENTAL;
+    INCREMENTAL, REPLACE;
 
     public String toString() {
       return name().toLowerCase(US);
@@ -259,8 +260,8 @@ public interface DocIdPusher {
    *
    * @param defs map of group definitions
    * @param caseSensitive when comparing Principals
-   * @param feedType if INCREMENTAL, an incremental update is done; if FULL, a
-   *        full replacement is done.
+   * @param feedType if INCREMENTAL, an incremental update is done;
+   *        if REPLACE, a full replacement is done.
    * @param groupSource the feed data source name
    * @param handler for dealing with errors pushing
    * @return {@code null} on success, otherwise the first GroupPrincipal to fail

--- a/src/com/google/enterprise/adaptor/DocIdSender.java
+++ b/src/com/google/enterprise/adaptor/DocIdSender.java
@@ -14,8 +14,8 @@
 
 package com.google.enterprise.adaptor;
 
-import static com.google.enterprise.adaptor.DocIdPusher.FeedType.FULL;
 import static com.google.enterprise.adaptor.DocIdPusher.FeedType.INCREMENTAL;
+import static com.google.enterprise.adaptor.DocIdPusher.FeedType.REPLACE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -231,9 +231,10 @@ class DocIdSender extends AbstractDocIdPusher
   }
 
   /**
-   * Issue: When full group pushes exceed permissible size of single feed.
+   * Issue: When full replacement group pushes exceed permissible size of
+   * single feed.
    *
-   * The problem with supplying all the group definitions in a single full
+   * The problem with supplying all the group definitions in a single REPLACE
    * feed is the GSA limit to the size of a feed file (1GB). Although this
    * is a large limit, several of our customers would easily exceed that.
    * One customer has 100,000 groups averaging 10,000 members each. Another
@@ -241,21 +242,21 @@ class DocIdSender extends AbstractDocIdPusher
    *
    * A novel solution to this is to double-buffer the group definitions for
    * each data source. We maintain two pseudo data sources for each actual
-   * data source (*-FULL1 and *-FULL2). Each "full" upload alternates between
+   * data source (*-REPL1 and *-REPL2). Each REPLACE upload alternates between
    * these two, using batches of incremental feeds.
    * Once all batches have been uploaded, We then "delete" the previous entries
-   * by sending an empty, but true full feed for the older data source. After
+   * by sending a "cleanup" feed for the older data source. After
    * this, the GSA should only have group definitions for the newer data source.
    *
    * If there is a failure mid-push, the GSA groups database may have entries
    * for both data sources. Since the adaptors do not maintain persistent
    * state, on a restart it will not know which is "older" vs. "newer".
    * This is not fatal however, as the only downside might be some deleted
-   * groups persisting through one or two "full" pushes before they get
+   * groups persisting through one or two REPLACE pushes before they get
    * cleaned up.
    *
    * This maps the connector-supplied group source to the last used pseudonym,
-   * e.g. {@code foo -> foo-FULL1}.
+   * e.g. {@code foo -> foo-REPL1}.
    */
   private Map<String, String> groupSources = new HashMap<String, String>();
 
@@ -264,9 +265,9 @@ class DocIdSender extends AbstractDocIdPusher
    * group source, returns the supplied source. If a connector only ever does
    * INCREMENTAL feeds, then that group source will always be used. This is
    * also backward compatible. If a connector is upgraded to a new version that
-   * supports FULL feeds, then the older incremental group source will
-   * eventually get deleted from the GSA. If a connector does both FULL and
-   * INCREMENTAL feeds, then an incremental feed will use the last FULL feed
+   * supports REPLACE feeds, then the older incremental group source will
+   * eventually get deleted from the GSA. If a connector does both REPLACE and
+   * INCREMENTAL feeds, then an incremental feed will use the last REPLACE feed
    * name used for the source.
    */
   private String previousGroupSource(String source) {
@@ -276,8 +277,8 @@ class DocIdSender extends AbstractDocIdPusher
 
   /** Returns the alternate to the previous group source. */
   private String alternateGroupSource(String source) {
-    return (source + "-FULL1").equals(groupSources.get(source))
-        ? (source + "-FULL2") : (source + "-FULL1");
+    return (source + "-REPL1").equals(groupSources.get(source))
+        ? (source + "-REPL2") : (source + "-REPL1");
   }
 
   /*
@@ -332,7 +333,7 @@ class DocIdSender extends AbstractDocIdPusher
       journal.recordGroupPushFailed();
       return defs.isEmpty() ? null : defs.keySet().iterator().next();
     }
-    if (feedType == FULL && !gsaVersion.isAtLeast("7.4.0-0")) {
+    if (feedType == REPLACE && !gsaVersion.isAtLeast("7.4.0-0")) {
       log.log(Level.WARNING,
           "GSA ver {0} does not support per-source replacement of all groups",
           gsaVerString);
@@ -411,7 +412,7 @@ class DocIdSender extends AbstractDocIdPusher
       log.finer("mean size of groups: " + mean);
     }
 
-    if (feedType == FULL) {
+    if (feedType == REPLACE) {
       String oldGroupSource;
       synchronized (groupSources) {
         // Remember the latest target group source fed.
@@ -480,19 +481,19 @@ class DocIdSender extends AbstractDocIdPusher
         keepGoing = false;  // Sent.
         success = true;
       } catch (IOException ex) {
-        log.log(Level.WARNING, "failed to cleanup groups", ex);
+        log.log(Level.WARNING, "Failed to cleanup groups", ex);
         keepGoing = handler.handleException(ex, ntries);
       }
       if (keepGoing) {
-        log.log(Level.INFO, "trying again... number of attempts: {0}", ntries);
+        log.log(Level.INFO, "Trying again... Number of attempts: {0}", ntries);
       }
     }
     if (success) {
-      log.log(Level.INFO, "cleanup of groups from {0} succeeded",
+      log.log(Level.INFO, "Cleanup of groups from {0} succeeded",
           feedSourceName);
       fileArchiver.saveFeed(feedSourceName, "cleanup");
     } else {
-      log.log(Level.WARNING, "gave up groups cleanup from {0}", feedSourceName);
+      log.log(Level.WARNING, "Gave up groups cleanup from {0}", feedSourceName);
       fileArchiver.saveFailedFeed(feedSourceName, "cleanup");
     }
   }

--- a/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
+++ b/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
@@ -14,6 +14,8 @@
 
 package com.google.enterprise.adaptor;
 
+import static java.util.Locale.US;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import java.io.ByteArrayInputStream;
@@ -107,9 +109,19 @@ class GsaFeedFileSender {
   private byte[] buildGroupsXmlMessage(String groupsource, String feedtype,
       String xmlDocument) {
     StringBuilder sb = new StringBuilder();
-    buildPostParameter(sb, "groupsource", "text/plain", groupsource);
-    buildPostParameter(sb, "feedtype", "text/plain", feedtype);
-    buildPostParameter(sb, "data", "text/xml", xmlDocument);
+    String ft = feedtype.toLowerCase(US);
+    if (ft.equals("full") || ft.equals("incremental")) {
+      buildPostParameter(sb, "groupsource", "text/plain", groupsource);
+      buildPostParameter(sb, "feedtype", "text/plain", feedtype);
+      buildPostParameter(sb, "data", "text/xml", xmlDocument);
+    } else if (ft.equals("cleanup")) {
+      buildPostParameter(sb, "cleanup", "text/plain", groupsource);
+    } else if (ft.equals("replace")) {
+      buildPostParameter(sb, "replace", "text/plain", groupsource);
+      buildPostParameter(sb, "data", "text/xml", xmlDocument);
+    } else {
+      throw new IllegalArgumentException("invalid feedtype: " + feedtype);
+    }
     sb.append("--").append(BOUNDARY).append("--").append(CRLF);
     return toEncodedBytes("" + sb);
   }

--- a/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
+++ b/src/com/google/enterprise/adaptor/GsaFeedFileSender.java
@@ -106,19 +106,20 @@ class GsaFeedFileSender {
     return toEncodedBytes("" + sb);
   }
 
+  /**
+   * Builds the multipart HTTP message for uploading group definitions.
+   * @throws NullPointerException if feedtype is null.
+   */
   private byte[] buildGroupsXmlMessage(String groupsource, String feedtype,
       String xmlDocument) {
     StringBuilder sb = new StringBuilder();
     String ft = feedtype.toLowerCase(US);
-    if (ft.equals("full") || ft.equals("incremental")) {
+    if (ft.equals("incremental")) {
       buildPostParameter(sb, "groupsource", "text/plain", groupsource);
       buildPostParameter(sb, "feedtype", "text/plain", feedtype);
       buildPostParameter(sb, "data", "text/xml", xmlDocument);
     } else if (ft.equals("cleanup")) {
       buildPostParameter(sb, "cleanup", "text/plain", groupsource);
-    } else if (ft.equals("replace")) {
-      buildPostParameter(sb, "replace", "text/plain", groupsource);
-      buildPostParameter(sb, "data", "text/xml", xmlDocument);
     } else {
       throw new IllegalArgumentException("invalid feedtype: " + feedtype);
     }

--- a/src/com/google/enterprise/adaptor/testing/RecordingDocIdPusher.java
+++ b/src/com/google/enterprise/adaptor/testing/RecordingDocIdPusher.java
@@ -96,7 +96,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
     }
     Map<GroupPrincipal, Collection<Principal>> groups =
         groupsBySource.get(sourceName);
-    if (groups == null || feedType == FeedType.FULL) {
+    if (groups == null || feedType == FeedType.REPLACE) {
       groups = new TreeMap<GroupPrincipal, Collection<Principal>>();
       groupsBySource.put(sourceName, groups);
     }

--- a/test/com/google/enterprise/adaptor/DocIdSenderTest.java
+++ b/test/com/google/enterprise/adaptor/DocIdSenderTest.java
@@ -412,15 +412,15 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(3, fileMaker.i);
-    assertEquals(expectedResult(2, sampleGroups(), emptyGroups()),
+    assertEquals(2, fileMaker.i);
+    assertEquals(expectedResult(2, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "incremental", "full"),
+    assertEquals(ImmutableList.of("incremental", "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo-FULL1", "foo"),
         fileSender.groupsources);
-    assertEquals(ImmutableList.of("0", "1", "2"), fileSender.xmlStrings);
-    assertEquals(ImmutableList.of("0", "1", "2"), fileArchiver.feeds);
+    assertEquals(ImmutableList.of("0", "1", ""), fileSender.xmlStrings);
+    assertEquals(ImmutableList.of("0", "1", "cleanup"), fileArchiver.feeds);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
   }
 
@@ -431,14 +431,14 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(2, fileMaker.i);
+    assertEquals(1, fileMaker.i);
     assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups(), emptyGroups()),
+        expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
-    assertEquals(ImmutableList.of("0", "1"), fileSender.xmlStrings);
-    assertEquals(ImmutableList.of("0", "1"), fileArchiver.feeds);
+    assertEquals(ImmutableList.of("0", ""), fileSender.xmlStrings);
+    assertEquals(ImmutableList.of("0", "cleanup"), fileArchiver.feeds);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
   }
@@ -450,21 +450,20 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(2, fileMaker.i);
-    assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups(), emptyGroups()),
+    assertEquals(1, fileMaker.i);
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(4, fileMaker.i);
+    assertEquals(2, fileMaker.i);
     assertEquals(expectedResult(Integer.MAX_VALUE,
-        sampleGroups(), emptyGroups(), sampleGroups(), emptyGroups()),
+        sampleGroups(), sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full", "incremental", "full"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL2", "foo-FULL1"),
         fileSender.groupsources);
@@ -479,21 +478,19 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(2, fileMaker.i);
-    assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups(), emptyGroups()),
+    assertEquals(1, fileMaker.i);
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(emptyGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(3, fileMaker.i);
-    assertEquals(expectedResult(Integer.MAX_VALUE,
-        sampleGroups(), emptyGroups(), emptyGroups()),
+    assertEquals(1, fileMaker.i);
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full", "full"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "cleanup"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
         fileSender.groupsources);
@@ -509,21 +506,21 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(2, fileMaker.i);
+    assertEquals(1, fileMaker.i);
     assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups(), emptyGroups()),
+        expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(emptyGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
-    assertEquals(2, fileMaker.i);
+    assertEquals(1, fileMaker.i);
     assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups(), emptyGroups()),
+        expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
@@ -542,7 +539,7 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "incremental", "full"),
+    assertEquals(ImmutableList.of("incremental", "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo", "foo-FULL1", "foo"),
         fileSender.groupsources);
@@ -551,8 +548,8 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "incremental", "full", "incremental",
-                         "full"),
+        ImmutableList.of("incremental", "incremental", "cleanup", "incremental",
+                         "cleanup"),
         fileSender.feedtypes);
     assertEquals(
         ImmutableList.of("foo", "foo-FULL1", "foo", "foo-FULL2", "foo-FULL1"),
@@ -567,13 +564,13 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "full", "incremental"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
         fileSender.groupsources);
@@ -582,7 +579,7 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "full", "incremental", "incremental"),
+        ImmutableList.of("incremental", "cleanup", "incremental", "incremental"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL1"),
         fileSender.groupsources);
@@ -596,13 +593,13 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "full", "incremental"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
         fileSender.groupsources);
@@ -611,8 +608,8 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "full", "incremental", "incremental",
-                         "full"),
+        ImmutableList.of("incremental", "cleanup", "incremental", "incremental",
+                         "cleanup"),
         fileSender.feedtypes);
     assertEquals(
         ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL2",
@@ -623,8 +620,8 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "full", "incremental", "incremental",
-                         "full", "incremental"),
+        ImmutableList.of("incremental", "cleanup", "incremental", "incremental",
+                         "cleanup", "incremental"),
         fileSender.feedtypes);
     assertEquals(
         ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL2",
@@ -639,13 +636,13 @@ public class DocIdSenderTest {
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "full"), fileSender.feedtypes);
+    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, FULL, "bar", null));
 
-    assertEquals(ImmutableList.of("incremental", "full", "incremental", "full"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(ImmutableList.of("foo-FULL1", "foo", "bar-FULL1", "bar"),
         fileSender.groupsources);
@@ -654,7 +651,7 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "full", "incremental", "full",
+        ImmutableList.of("incremental", "cleanup", "incremental", "cleanup",
                          "incremental"),
         fileSender.feedtypes);
     assertEquals(
@@ -665,7 +662,7 @@ public class DocIdSenderTest {
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "bar", null));
 
     assertEquals(
-        ImmutableList.of("incremental", "full", "incremental", "full",
+        ImmutableList.of("incremental", "cleanup", "incremental", "cleanup",
                          "incremental", "incremental"),
         fileSender.feedtypes);
     assertEquals(
@@ -738,7 +735,7 @@ public class DocIdSenderTest {
         new NeverRetryExceptionHandler()));
 
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
-    assertEquals(ImmutableList.of("0"), fileArchiver.failedFeeds);
+    assertEquals(ImmutableList.of("cleanup"), fileArchiver.failedFeeds);
     assertTrue(fileArchiver.feeds.isEmpty());
   }
 

--- a/test/com/google/enterprise/adaptor/DocIdSenderTest.java
+++ b/test/com/google/enterprise/adaptor/DocIdSenderTest.java
@@ -15,8 +15,8 @@
 package com.google.enterprise.adaptor;
 
 import static com.google.enterprise.adaptor.DocIdPusher.EVERYTHING_CASE_SENSITIVE;
-import static com.google.enterprise.adaptor.DocIdPusher.FeedType.FULL;
 import static com.google.enterprise.adaptor.DocIdPusher.FeedType.INCREMENTAL;
+import static com.google.enterprise.adaptor.DocIdPusher.FeedType.REPLACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -392,7 +392,7 @@ public class DocIdSenderTest {
   public void testPushGroupsReplaceAllGroupsBeforeVersion74() throws Exception {
     config.setValue("feed.maxUrls", "2");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(2, fileMaker.i);
     assertEquals(expectedResult(2, sampleGroups()), fileMaker.groupses);
@@ -410,14 +410,14 @@ public class DocIdSenderTest {
     config.setValue("feed.maxUrls", "2");
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(2, fileMaker.i);
     assertEquals(expectedResult(2, sampleGroups()),
         fileMaker.groupses);
     assertEquals(ImmutableList.of("incremental", "incremental", "cleanup"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo-FULL1", "foo"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo-REPL1", "foo"),
         fileSender.groupsources);
     assertEquals(ImmutableList.of("0", "1", ""), fileSender.xmlStrings);
     assertEquals(ImmutableList.of("0", "1", "cleanup"), fileArchiver.feeds);
@@ -429,14 +429,14 @@ public class DocIdSenderTest {
   public void testPushGroupsReplaceAllGroupsSingleFeed() throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(1, fileMaker.i);
-    assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups()),
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
     assertEquals(ImmutableList.of("0", ""), fileSender.xmlStrings);
     assertEquals(ImmutableList.of("0", "cleanup"), fileArchiver.feeds);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
@@ -448,24 +448,26 @@ public class DocIdSenderTest {
   public void testPushGroupsReplaceAllGroupsAlternateBuffer() throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(1, fileMaker.i);
     assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(2, fileMaker.i);
     assertEquals(expectedResult(Integer.MAX_VALUE,
         sampleGroups(), sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental", "cleanup"),
+    assertEquals(
+        ImmutableList.of("incremental", "cleanup", "incremental", "cleanup"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL2", "foo-FULL1"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "foo-REPL2", "foo-REPL1"),
         fileSender.groupsources);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
@@ -476,23 +478,24 @@ public class DocIdSenderTest {
   public void testPushGroupsReplaceAllGroupsEmptyFullFeed() throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(1, fileMaker.i);
     assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(emptyGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(1, fileMaker.i);
     assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
     assertEquals(ImmutableList.of("incremental", "cleanup", "cleanup"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "foo-REPL1"),
         fileSender.groupsources);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
@@ -504,24 +507,24 @@ public class DocIdSenderTest {
       throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(1, fileMaker.i);
-    assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups()),
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(emptyGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(1, fileMaker.i);
-    assertEquals(
-        expectedResult(Integer.MAX_VALUE, sampleGroups()),
+    assertEquals(expectedResult(Integer.MAX_VALUE, sampleGroups()),
         fileMaker.groupses);
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
     assertTrue(fileArchiver.failedFeeds.isEmpty());
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());
   }
@@ -537,22 +540,21 @@ public class DocIdSenderTest {
     assertEquals(ImmutableList.of("foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
     assertEquals(ImmutableList.of("incremental", "incremental", "cleanup"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo", "foo-FULL1", "foo"),
+    assertEquals(ImmutableList.of("foo", "foo-REPL1", "foo"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
-    assertEquals(
-        ImmutableList.of("incremental", "incremental", "cleanup", "incremental",
-                         "cleanup"),
+    assertEquals(ImmutableList.of("incremental", "incremental", "cleanup",
+            "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(
-        ImmutableList.of("foo", "foo-FULL1", "foo", "foo-FULL2", "foo-FULL1"),
+        ImmutableList.of("foo", "foo-REPL1", "foo", "foo-REPL2", "foo-REPL1"),
         fileSender.groupsources);
   }
 
@@ -562,26 +564,27 @@ public class DocIdSenderTest {
       throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(ImmutableList.of("incremental", "cleanup", "incremental"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "foo-REPL1"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
-    assertEquals(
-        ImmutableList.of("incremental", "cleanup", "incremental", "incremental"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental",
+            "incremental"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL1"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "foo-REPL1", "foo-REPL1"),
         fileSender.groupsources);
   }
 
@@ -591,41 +594,40 @@ public class DocIdSenderTest {
       throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
     assertEquals(ImmutableList.of("incremental", "cleanup", "incremental"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "foo-FULL1"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "foo-REPL1"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
-    assertEquals(
-        ImmutableList.of("incremental", "cleanup", "incremental", "incremental",
-                         "cleanup"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental",
+            "incremental", "cleanup"),
         fileSender.feedtypes);
     assertEquals(
-        ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL2",
-                         "foo-FULL1"),
+        ImmutableList.of("foo-REPL1", "foo", "foo-REPL1", "foo-REPL2",
+                         "foo-REPL1"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "foo", null));
 
-    assertEquals(
-        ImmutableList.of("incremental", "cleanup", "incremental", "incremental",
-                         "cleanup", "incremental"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental",
+            "incremental", "cleanup", "incremental"),
         fileSender.feedtypes);
     assertEquals(
-        ImmutableList.of("foo-FULL1", "foo", "foo-FULL1", "foo-FULL2",
-                         "foo-FULL1", "foo-FULL2"),
+        ImmutableList.of("foo-REPL1", "foo", "foo-REPL1", "foo-REPL2",
+                         "foo-REPL1", "foo-REPL2"),
         fileSender.groupsources);
   }
 
@@ -634,17 +636,19 @@ public class DocIdSenderTest {
   public void testPushGroupsFromMultipleGroupSources() throws Exception {
     config.setValue("gsa.version", "7.4.0-1");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "foo", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "foo", null));
 
-    assertEquals(ImmutableList.of("incremental", "cleanup"), fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo"), fileSender.groupsources);
+    assertEquals(ImmutableList.of("incremental", "cleanup"),
+        fileSender.feedtypes);
+    assertEquals(ImmutableList.of("foo-REPL1", "foo"), fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, "bar", null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, "bar", null));
 
-    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental", "cleanup"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental",
+            "cleanup"),
         fileSender.feedtypes);
-    assertEquals(ImmutableList.of("foo-FULL1", "foo", "bar-FULL1", "bar"),
+    assertEquals(ImmutableList.of("foo-REPL1", "foo", "bar-REPL1", "bar"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
@@ -655,19 +659,18 @@ public class DocIdSenderTest {
                          "incremental"),
         fileSender.feedtypes);
     assertEquals(
-        ImmutableList.of("foo-FULL1", "foo", "bar-FULL1", "bar", "foo-FULL1"),
+        ImmutableList.of("foo-REPL1", "foo", "bar-REPL1", "bar", "foo-REPL1"),
         fileSender.groupsources);
 
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
         EVERYTHING_CASE_SENSITIVE, INCREMENTAL, "bar", null));
 
-    assertEquals(
-        ImmutableList.of("incremental", "cleanup", "incremental", "cleanup",
-                         "incremental", "incremental"),
+    assertEquals(ImmutableList.of("incremental", "cleanup", "incremental",
+            "cleanup", "incremental", "incremental"),
         fileSender.feedtypes);
     assertEquals(
-        ImmutableList.of("foo-FULL1", "foo", "bar-FULL1", "bar", "foo-FULL1",
-                         "bar-FULL1"),
+        ImmutableList.of("foo-REPL1", "foo", "bar-REPL1", "bar", "foo-REPL1",
+                         "bar-REPL1"),
         fileSender.groupsources);
   }
 
@@ -675,7 +678,7 @@ public class DocIdSenderTest {
   public void testPushGroupsNoGroupSource() throws Exception {
     config.setValue("feed.name", "default_source");
     assertNull(docIdSender.pushGroupDefinitions(sampleGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, null, null));
+        EVERYTHING_CASE_SENSITIVE, REPLACE, null, null));
 
     assertEquals(Collections.singletonList("default_source"),
         fileSender.groupsources);
@@ -731,7 +734,7 @@ public class DocIdSenderTest {
     // intended to remove previous group definitions will. The return
     // from pushSizedBatchOfGroups() will be null, simulating SUCCESS.
     assertNull(docIdSender.pushGroupDefinitions(emptyGroups(),
-        EVERYTHING_CASE_SENSITIVE, FULL, null,
+        EVERYTHING_CASE_SENSITIVE, REPLACE, null,
         new NeverRetryExceptionHandler()));
 
     assertEquals(CompletionStatus.SUCCESS, journal.getLastGroupPushStatus());

--- a/test/com/google/enterprise/adaptor/GsaFeedFileSenderTest.java
+++ b/test/com/google/enterprise/adaptor/GsaFeedFileSenderTest.java
@@ -317,8 +317,65 @@ public class GsaFeedFileSenderTest {
   }
 
   @Test
+  public void testGroupsSuccess_Replace() throws Exception {
+    final String payload = "<someXmlString/>";
+    final String groupsource = "docspot";
+    final String goldenResponse
+        = "--<<\r\n"
+        + "Content-Disposition: form-data; name=\"replace\"\r\n"
+        + "Content-Type: text/plain\r\n"
+        + "\r\n"
+        + groupsource + "\r\n"
+        + "--<<\r\n"
+        + "Content-Disposition: form-data; name=\"data\"\r\n"
+        + "Content-Type: text/xml\r\n"
+        + "\r\n"
+        + payload + "\r\n"
+        + "--<<--\r\n";
+    MockHttpHandler handler
+        = new MockHttpHandler(200, "Success".getBytes(charset));
+    server.createContext("/xmlgroups", handler);
+    sender.sendGroups(groupsource, "replace", payload, false);
+    assertEquals("POST", handler.getRequestMethod());
+    assertEquals(URI.create("/xmlgroups"), handler.getRequestUri());
+    assertEquals("multipart/form-data; boundary=<<",
+        handler.getRequestHeaders().getFirst("Content-Type"));
+    assertEquals(goldenResponse,
+        new String(handler.getRequestBytes(), charset));
+  }
+
+  @Test
+  public void testGroupsSuccess_Cleanup() throws Exception {
+    final String payload = "<someXmlString/>";
+    final String groupsource = "docspot";
+    final String goldenResponse
+        = "--<<\r\n"
+        + "Content-Disposition: form-data; name=\"cleanup\"\r\n"
+        + "Content-Type: text/plain\r\n"
+        + "\r\n"
+        + groupsource + "\r\n"
+        + "--<<--\r\n";
+    MockHttpHandler handler
+        = new MockHttpHandler(200, "Success".getBytes(charset));
+    server.createContext("/xmlgroups", handler);
+    sender.sendGroups(groupsource, "cleanup", payload, false);
+    assertEquals("POST", handler.getRequestMethod());
+    assertEquals(URI.create("/xmlgroups"), handler.getRequestUri());
+    assertEquals("multipart/form-data; boundary=<<",
+        handler.getRequestHeaders().getFirst("Content-Type"));
+    assertEquals(goldenResponse,
+        new String(handler.getRequestBytes(), charset));
+  }
+
+  @Test
   public void testGroupsInvalidGroupSource() throws Exception {
     thrown.expect(IllegalArgumentException.class);
     sender.sendGroups("bad#source", "full", "<payload/>", false);
+  }
+
+  @Test
+  public void testGroupsInvalidFeedType() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    sender.sendGroups("groupsource", "invalid", "<payload/>", false);
   }
 }

--- a/test/com/google/enterprise/adaptor/GsaFeedFileSenderTest.java
+++ b/test/com/google/enterprise/adaptor/GsaFeedFileSenderTest.java
@@ -284,67 +284,6 @@ public class GsaFeedFileSenderTest {
   }
 
   @Test
-  public void testGroupsSuccess_Full() throws Exception {
-    final String payload = "<someXmlString/>";
-    final String groupsource = "docspot";
-    final String goldenResponse
-        = "--<<\r\n"
-        + "Content-Disposition: form-data; name=\"groupsource\"\r\n"
-        + "Content-Type: text/plain\r\n"
-        + "\r\n"
-        + groupsource + "\r\n"
-        + "--<<\r\n"
-        + "Content-Disposition: form-data; name=\"feedtype\"\r\n"
-        + "Content-Type: text/plain\r\n"
-        + "\r\n"
-        + "full\r\n"
-        + "--<<\r\n"
-        + "Content-Disposition: form-data; name=\"data\"\r\n"
-        + "Content-Type: text/xml\r\n"
-        + "\r\n"
-        + payload + "\r\n"
-        + "--<<--\r\n";
-    MockHttpHandler handler
-        = new MockHttpHandler(200, "Success".getBytes(charset));
-    server.createContext("/xmlgroups", handler);
-    sender.sendGroups(groupsource, "full", payload, false);
-    assertEquals("POST", handler.getRequestMethod());
-    assertEquals(URI.create("/xmlgroups"), handler.getRequestUri());
-    assertEquals("multipart/form-data; boundary=<<",
-        handler.getRequestHeaders().getFirst("Content-Type"));
-    assertEquals(goldenResponse,
-        new String(handler.getRequestBytes(), charset));
-  }
-
-  @Test
-  public void testGroupsSuccess_Replace() throws Exception {
-    final String payload = "<someXmlString/>";
-    final String groupsource = "docspot";
-    final String goldenResponse
-        = "--<<\r\n"
-        + "Content-Disposition: form-data; name=\"replace\"\r\n"
-        + "Content-Type: text/plain\r\n"
-        + "\r\n"
-        + groupsource + "\r\n"
-        + "--<<\r\n"
-        + "Content-Disposition: form-data; name=\"data\"\r\n"
-        + "Content-Type: text/xml\r\n"
-        + "\r\n"
-        + payload + "\r\n"
-        + "--<<--\r\n";
-    MockHttpHandler handler
-        = new MockHttpHandler(200, "Success".getBytes(charset));
-    server.createContext("/xmlgroups", handler);
-    sender.sendGroups(groupsource, "replace", payload, false);
-    assertEquals("POST", handler.getRequestMethod());
-    assertEquals(URI.create("/xmlgroups"), handler.getRequestUri());
-    assertEquals("multipart/form-data; boundary=<<",
-        handler.getRequestHeaders().getFirst("Content-Type"));
-    assertEquals(goldenResponse,
-        new String(handler.getRequestBytes(), charset));
-  }
-
-  @Test
   public void testGroupsSuccess_Cleanup() throws Exception {
     final String payload = "<someXmlString/>";
     final String groupsource = "docspot";

--- a/test/com/google/enterprise/adaptor/testing/RecordingDocIdPusherTest.java
+++ b/test/com/google/enterprise/adaptor/testing/RecordingDocIdPusherTest.java
@@ -16,8 +16,8 @@ package com.google.enterprise.adaptor.testing;
 
 import static com.google.enterprise.adaptor.DocIdPusher.EVERYTHING_CASE_INSENSITIVE;
 import static com.google.enterprise.adaptor.DocIdPusher.EVERYTHING_CASE_SENSITIVE;
-import static com.google.enterprise.adaptor.DocIdPusher.FeedType.FULL;
 import static com.google.enterprise.adaptor.DocIdPusher.FeedType.INCREMENTAL;
+import static com.google.enterprise.adaptor.DocIdPusher.FeedType.REPLACE;
 import static com.google.enterprise.adaptor.DocIdPusher.Record;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -189,12 +189,12 @@ public class RecordingDocIdPusherTest {
         new GroupPrincipal("group5"),
             ImmutableSet.<Principal>of(new UserPrincipal("user500")));
 
-    pusher.pushGroupDefinitions(groups123, EVERYTHING_CASE_SENSITIVE, FULL,
+    pusher.pushGroupDefinitions(groups123, EVERYTHING_CASE_SENSITIVE, REPLACE,
         source, null);
     Map<GroupPrincipal, Set<Principal>> expected = Maps.newHashMap(groups123);
     assertEquals(expected, pusher.getGroupDefinitions());
 
-    pusher.pushGroupDefinitions(groups456, EVERYTHING_CASE_SENSITIVE, FULL,
+    pusher.pushGroupDefinitions(groups456, EVERYTHING_CASE_SENSITIVE, REPLACE,
         source, null);
     expected = Maps.newHashMap(groups456);
     assertEquals(expected, pusher.getGroupDefinitions());
@@ -226,9 +226,9 @@ public class RecordingDocIdPusherTest {
         new GroupPrincipal("group6"),
             ImmutableSet.<Principal>of(new UserPrincipal("user6")));
 
-    pusher.pushGroupDefinitions(groups123, EVERYTHING_CASE_SENSITIVE, FULL,
+    pusher.pushGroupDefinitions(groups123, EVERYTHING_CASE_SENSITIVE, REPLACE,
         "foo", null);
-    pusher.pushGroupDefinitions(groups456, EVERYTHING_CASE_SENSITIVE, FULL,
+    pusher.pushGroupDefinitions(groups456, EVERYTHING_CASE_SENSITIVE, REPLACE,
         "bar", null);
     assertEquals(groups123, pusher.getGroupDefinitions("foo"));
     assertEquals(groups456, pusher.getGroupDefinitions("bar"));
@@ -257,10 +257,10 @@ public class RecordingDocIdPusherTest {
         new GroupPrincipal("group2"),
             ImmutableSet.<Principal>of(new UserPrincipal("user2")));
 
-    pusher.pushGroupDefinitions(groups1, EVERYTHING_CASE_SENSITIVE, FULL, "foo",
-        null);
-    pusher.pushGroupDefinitions(groups2, EVERYTHING_CASE_SENSITIVE, FULL, "bar",
-        null);
+    pusher.pushGroupDefinitions(groups1, EVERYTHING_CASE_SENSITIVE, REPLACE,
+        "foo", null);
+    pusher.pushGroupDefinitions(groups2, EVERYTHING_CASE_SENSITIVE, REPLACE,
+        "bar", null);
 
     thrown.expect(IllegalStateException.class);
     pusher.getGroupDefinitions();


### PR DESCRIPTION
It turns out the GSA does not support per-groupsource full feeds.
Any feed with "feedtype=full" replaces all groups from all sources.
But the GSA does support a feed of "cleanup=groupsource" that does
exactly what we need, it removes all group definitions from that
groupsource, so I enhanced GsaFeedFileSender to support cleanup feeds.

Also added "replace=groupsource" support to GsaFeedFileSender since
this file is shared with the GsaFeed project.