### PR TITLE
Flag javac options warnings on the first call.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -146,7 +146,8 @@
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
       target="${compile.java.version}" source="${compile.java.version}">
-      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial -Xlint:-options"/>
+      <!-- Do not suppress options warnings on this first call. -->
+      <compilerarg line="-Xlint -Xlint:-path -Xlint:-serial"/>
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <classpath refid="adaptorlib.build.classpath"/>
       <exclude name="${adaptor.pkg.dir}/examples/**"/>


### PR DESCRIPTION
This was added in commit 2e4f46f to avoid warnings about -source and
-target values of 1.6 when compiling with Java 9. But it also
suppresses the warning that the bootclasspath has not been set in
conjunction with the source and target, which is a potential error.

Continue to suppress warnings on the subsequent calls to avoid noise.