### PR TITLE
Read-only tweaks to the Recording classes.

### DIFF
--- a/src/com/google/enterprise/adaptor/testing/RecordingDocIdPusher.java
+++ b/src/com/google/enterprise/adaptor/testing/RecordingDocIdPusher.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.adaptor.testing;
 
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 
 import com.google.enterprise.adaptor.AbstractDocIdPusher;
@@ -44,10 +45,11 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
   // configuration property.
   private static final String DEFAULT_SOURCE = "${feed.name}";
 
-  private List<DocId> ids = new ArrayList<DocId>();
-  private List<Record> records = new ArrayList<Record>();
-  private Map<DocId, Acl> namedResources = new TreeMap<DocId, Acl>();
-  private Map<String, Map<GroupPrincipal, Collection<Principal>>> groupsBySource
+  private final List<DocId> ids = new ArrayList<DocId>();
+  private final List<Record> records = new ArrayList<Record>();
+  private final Map<DocId, Acl> namedResources = new TreeMap<DocId, Acl>();
+  private final Map<String, Map<GroupPrincipal, Collection<Principal>>>
+      groupsBySource
       = new HashMap<String, Map<GroupPrincipal, Collection<Principal>>>();
 
   /**
@@ -125,7 +127,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
    * @return an unmodifiable list of the recorded {@link DocId DocIds}
    */
   public List<DocId> getDocIds() {
-    return Collections.unmodifiableList(ids);
+    return unmodifiableList(ids);
   }
 
   /**
@@ -135,7 +137,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
    * @return an unmodifiable list of the recorded {@link Record Records}
    */
   public List<Record> getRecords() {
-    return Collections.unmodifiableList(records);
+    return unmodifiableList(records);
   }
 
   /**
@@ -148,7 +150,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
    * @return an unmodifiable map of the recorded named resources
    */
   public Map<DocId, Acl> getNamedResources() {
-    return Collections.unmodifiableMap(namedResources);
+    return unmodifiableMap(namedResources);
   }
 
   /**
@@ -165,8 +167,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
       case 0:
         return Collections.<GroupPrincipal, Collection<Principal>>emptyMap();
       case 1:
-        return Collections.unmodifiableMap(
-            groupsBySource.values().iterator().next());
+        return unmodifiableMap(groupsBySource.values().iterator().next());
       default:
         throw new IllegalStateException("More than 1 group source");
     }
@@ -192,7 +193,7 @@ public class RecordingDocIdPusher extends AbstractDocIdPusher {
     if (groups == null) {
       return Collections.<GroupPrincipal, Collection<Principal>>emptyMap();
     } else {
-      return Collections.unmodifiableMap(groups);
+      return unmodifiableMap(groups);
     }
   }
 

--- a/src/com/google/enterprise/adaptor/testing/RecordingResponse.java
+++ b/src/com/google/enterprise/adaptor/testing/RecordingResponse.java
@@ -14,6 +14,10 @@
 
 package com.google.enterprise.adaptor.testing;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Collections.unmodifiableSet;
+
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.Metadata;
 import com.google.enterprise.adaptor.MetadataTransform.TransmissionDecision;
@@ -48,11 +52,11 @@ public class RecordingResponse implements Response {
   private State state = State.SETUP;
   private String contentType;
   private Date lastModified;
-  private Metadata metadata = new Metadata();
+  private final Metadata metadata = new Metadata();
   private Acl acl;
-  private Map<String, Acl> namedResources = new TreeMap<String, Acl>();
+  private final Map<String, Acl> namedResources = new TreeMap<String, Acl>();
   private boolean secure;
-  private List<Map.Entry<String, URI>> anchors =
+  private final List<Map.Entry<String, URI>> anchors =
       new ArrayList<Map.Entry<String, URI>>();
   private boolean noIndex;
   private boolean noFollow;
@@ -61,7 +65,7 @@ public class RecordingResponse implements Response {
   private boolean crawlOnce;
   private boolean lock;
   private TransmissionDecision forcedTransmissionDecision;
-  private Map<String, String> params = new TreeMap<String, String>();
+  private final Map<String, String> params = new TreeMap<String, String>();
 
   /**
    * Constructs a mock {@code Response} with a {@code ByteArrayOutputStream}.
@@ -266,7 +270,7 @@ public class RecordingResponse implements Response {
   }
 
   public Map<String, Acl> getNamedResources() {
-    return namedResources;
+    return unmodifiableMap(namedResources);
   }
 
   public boolean isSecure() {
@@ -274,12 +278,12 @@ public class RecordingResponse implements Response {
   }
 
   /**
-   * Gets a modifiable list of the accumulated anchors.
+   * Gets an unmodifiable list of the accumulated anchors.
    *
-   * @return a modifiable list of the accumulated anchors
+   * @return a unmodifiable list of the accumulated anchors
    */
   public List<Map.Entry<String, URI>> getAnchors() {
-    return anchors;
+    return unmodifiableList(anchors);
   }
 
   public boolean isNoIndex() {
@@ -311,11 +315,11 @@ public class RecordingResponse implements Response {
   }
 
   /**
-   * Gets a modifiable map of the accumulated params.
+   * Gets an unmodifiable map of the accumulated params.
    *
-   * @return a modifiable map of the accumulated params
+   * @return an unmodifiable map of the accumulated params
    */
   public Map<String, String> getParams() {
-    return params;
+    return unmodifiableMap(params);
   }
 }

--- a/src/com/google/enterprise/adaptor/testing/RecordingResponse.java
+++ b/src/com/google/enterprise/adaptor/testing/RecordingResponse.java
@@ -16,7 +16,6 @@ package com.google.enterprise.adaptor.testing;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
 
 import com.google.enterprise.adaptor.Acl;
 import com.google.enterprise.adaptor.Metadata;


### PR DESCRIPTION
Use final fields and return unmodifiable collections.

Tested with the AD, DB, DCTM, and OT connectors.