### PR TITLE
Update Oracle javadoc links.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -409,8 +409,8 @@
       <classpath refid="adaptorlib.build.classpath"/>
       <classpath refid="examples.build.classpath"/>
       <classpath location="${lib.dir}/commons-fileupload-1.3.jar"/>
-      <link href="http://download.oracle.com/javase/6/docs/jre/api/net/httpserver/spec/"/>
-      <link href="http://download.oracle.com/javase/6/docs/api/"/>
+      <link href="https://docs.oracle.com/javase/6/docs/jre/api/net/httpserver/spec/"/>
+      <link href="https://docs.oracle.com/javase/6/docs/api/"/>
       <link href="http://commons.apache.org/proper/commons-daemon/apidocs/"/>
       <arg line="${java.modules}"/>
       <arg value="-quiet"/>


### PR DESCRIPTION
The old links are redirected, but javadoc doesn't follow the redirects
for -link options.