### PR TITLE
Fix PrebuiltTranform.replaceInParams empty and trimmed values

### DIFF
--- a/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
+++ b/src/com/google/enterprise/adaptor/prebuilt/PrebuiltTransforms.java
@@ -513,12 +513,12 @@ public class PrebuiltTransforms {
     }
 
     private void replaceInParams(String key, Map<String, String> params) {
-      String original = getTrimmedValue(params, key);
+      String original = params.get(key);
       if (original == null) {
         log.log(Level.FINE, "No param value for {0}. Skipping", key);
         return;
       }
-      if (overwrite || params.get(key) == null) {
+      if (overwrite) {
         log.log(Level.FINE,
             "Replacing {1} with {2} in param value of {0}: {3}",
             new Object[] {key, toMatch, replacement, original});

--- a/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
@@ -987,7 +987,9 @@ public class PrebuiltTransformsTest {
     config.put("keyset1", "params");
     config.put("key2", "author");
     config.put("keyset2", "metadata");
-    config.put("pattern", "[ ]+ ");
+    // Pattern with leading and trailing whitespace matches 2 or more spaces,
+    // replacing them with a single space.
+    config.put("pattern", " + ");
     config.put("replacement", " ");
     config = Collections.unmodifiableMap(config);
 
@@ -1009,6 +1011,8 @@ public class PrebuiltTransformsTest {
 
     Metadata metadata = new Metadata();
     metadata.add("author", "J.    D.  Salinger");
+    // Metadata and Param values with leading and trailing whitespace that
+    // that should match pattern.
     metadata.add("author", "   J.   K.  Rowlings   ");
     Map<String, String> params = new HashMap<String, String>();
     params.put("colour", "burnt   orange   ");

--- a/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
@@ -874,6 +874,187 @@ public class PrebuiltTransformsTest {
   }
 
   @Test
+  public void testReplacePatternWholeValue() {
+    Map<String, String> config = new LinkedHashMap<String, String>();
+    config.put("key1", "colour");
+    config.put("keyset1", "params");
+    config.put("key2", "author");
+    config.put("keyset2", "metadata");
+    config.put("pattern", "^.*$");
+    config.put("replacement", "test");
+    config = Collections.unmodifiableMap(config);
+
+    MetadataTransform transform = PrebuiltTransforms.replaceMetadata(config);
+
+    final Metadata metadataGolden;
+    {
+      Metadata golden = new Metadata();
+      golden.add("author", "test");
+      metadataGolden = golden.unmodifiableView();
+    }
+    final Map<String, String> paramsGolden;
+    {
+      Map<String, String> golden = new HashMap<String, String>();
+      golden.put("colour", "test");
+      paramsGolden = Collections.unmodifiableMap(golden);
+    }
+
+    Metadata metadata = new Metadata();
+    metadata.add("author", "J.D. Salinger");
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("colour", "red");
+    transform.transform(metadata, params);
+    assertEquals(metadataGolden, metadata);
+    assertEquals(paramsGolden, params);
+  }
+
+  @Test
+  public void testReplacePatternEmptyValue() {
+    Map<String, String> config = new LinkedHashMap<String, String>();
+    config.put("key1", "colour");
+    config.put("keyset1", "params");
+    config.put("key2", "author");
+    config.put("keyset2", "metadata");
+    config.put("pattern", "^$");
+    config.put("replacement", "test");
+    config = Collections.unmodifiableMap(config);
+
+    MetadataTransform transform = PrebuiltTransforms.replaceMetadata(config);
+
+    final Metadata metadataGolden;
+    {
+      Metadata golden = new Metadata();
+      golden.add("author", "J.D. Salinger");
+      golden.add("author", "test");
+      metadataGolden = golden.unmodifiableView();
+    }
+    final Map<String, String> paramsGolden;
+    {
+      Map<String, String> golden = new HashMap<String, String>();
+      golden.put("colour", "test");
+      paramsGolden = Collections.unmodifiableMap(golden);
+    }
+
+    Metadata metadata = new Metadata();
+    metadata.add("author", "J.D. Salinger");
+    metadata.add("author", "");
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("colour", "");
+    transform.transform(metadata, params);
+    assertEquals(metadataGolden, metadata);
+    assertEquals(paramsGolden, params);
+  }
+
+  @Test
+  public void testReplacePatternEmptyReplacement() {
+    Map<String, String> config = new LinkedHashMap<String, String>();
+    config.put("key1", "colour");
+    config.put("keyset1", "params");
+    config.put("key2", "author");
+    config.put("keyset2", "metadata");
+    config.put("pattern", "[aeiou]");
+    config.put("replacement", "");
+    config = Collections.unmodifiableMap(config);
+
+    MetadataTransform transform = PrebuiltTransforms.replaceMetadata(config);
+
+    final Metadata metadataGolden;
+    {
+      Metadata golden = new Metadata();
+      golden.add("author", "J.D. Slngr");
+      metadataGolden = golden.unmodifiableView();
+    }
+    final Map<String, String> paramsGolden;
+    {
+      Map<String, String> golden = new HashMap<String, String>();
+      golden.put("colour", "rd");
+      paramsGolden = Collections.unmodifiableMap(golden);
+    }
+
+    Metadata metadata = new Metadata();
+    metadata.add("author", "J.D. Salinger");
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("colour", "red");
+    transform.transform(metadata, params);
+    assertEquals(metadataGolden, metadata);
+    assertEquals(paramsGolden, params);
+  }
+
+  @Test
+  public void testReplacePatternUntrimmed() {
+    Map<String, String> config = new LinkedHashMap<String, String>();
+    config.put("key1", "colour");
+    config.put("keyset1", "params");
+    config.put("key2", "author");
+    config.put("keyset2", "metadata");
+    config.put("pattern", "[ ]+ ");
+    config.put("replacement", " ");
+    config = Collections.unmodifiableMap(config);
+
+    MetadataTransform transform = PrebuiltTransforms.replaceMetadata(config);
+
+    final Metadata metadataGolden;
+    {
+      Metadata golden = new Metadata();
+      golden.add("author", "J. D. Salinger");
+      golden.add("author", " J. K. Rowlings ");
+      metadataGolden = golden.unmodifiableView();
+    }
+    final Map<String, String> paramsGolden;
+    {
+      Map<String, String> golden = new HashMap<String, String>();
+      golden.put("colour", "burnt orange ");
+      paramsGolden = Collections.unmodifiableMap(golden);
+    }
+
+    Metadata metadata = new Metadata();
+    metadata.add("author", "J.    D.  Salinger");
+    metadata.add("author", "   J.   K.  Rowlings   ");
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("colour", "burnt   orange   ");
+    transform.transform(metadata, params);
+    assertEquals(metadataGolden, metadata);
+    assertEquals(paramsGolden, params);
+  }
+
+  @Test
+  public void testReplaceStringUntrimmed() {
+    Map<String, String> config = new LinkedHashMap<String, String>();
+    config.put("key1", "colour");
+    config.put("keyset1", "params");
+    config.put("key2", "author");
+    config.put("keyset2", "metadata");
+    config.put("string", "  ");
+    config.put("replacement", " ");
+    config = Collections.unmodifiableMap(config);
+
+    MetadataTransform transform = PrebuiltTransforms.replaceMetadata(config);
+
+    final Metadata metadataGolden;
+    {
+      Metadata golden = new Metadata();
+      golden.add("author", "J. D. Salinger");
+      golden.add("author", " J. K. Rowlings ");
+      metadataGolden = golden.unmodifiableView();
+    }
+    final Map<String, String> paramsGolden;
+    {
+      Map<String, String> golden = new HashMap<String, String>();
+      golden.put("colour", "burnt orange ");
+      paramsGolden = Collections.unmodifiableMap(golden);
+    }
+
+    Metadata metadata = new Metadata();
+    metadata.add("author", "J.  D.  Salinger");
+    metadata.add("author", "  J.  K.  Rowlings  ");
+    Map<String, String> params = new HashMap<String, String>();
+    params.put("colour", "burnt  orange  ");
+    transform.transform(metadata, params);
+    assertEquals(metadataGolden, metadata);
+    assertEquals(paramsGolden, params);
+  }
+
+  @Test
   public void testReplaceToString() {
     Map<String, String> config = new LinkedHashMap<String, String>();
     config.put("string", "tofind");

--- a/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
+++ b/test/com/google/enterprise/adaptor/prebuilt/PrebuiltTransformsTest.java
@@ -999,7 +999,7 @@ public class PrebuiltTransformsTest {
     {
       Metadata golden = new Metadata();
       golden.add("author", "J. D. Salinger");
-      golden.add("author", " J. K. Rowlings ");
+      golden.add("author", " J. K. Rowling ");
       metadataGolden = golden.unmodifiableView();
     }
     final Map<String, String> paramsGolden;
@@ -1013,7 +1013,7 @@ public class PrebuiltTransformsTest {
     metadata.add("author", "J.    D.  Salinger");
     // Metadata and Param values with leading and trailing whitespace that
     // that should match pattern.
-    metadata.add("author", "   J.   K.  Rowlings   ");
+    metadata.add("author", "   J.   K.  Rowling   ");
     Map<String, String> params = new HashMap<String, String>();
     params.put("colour", "burnt   orange   ");
     transform.transform(metadata, params);
@@ -1038,7 +1038,7 @@ public class PrebuiltTransformsTest {
     {
       Metadata golden = new Metadata();
       golden.add("author", "J. D. Salinger");
-      golden.add("author", " J. K. Rowlings ");
+      golden.add("author", " J. K. Rowling ");
       metadataGolden = golden.unmodifiableView();
     }
     final Map<String, String> paramsGolden;
@@ -1050,7 +1050,7 @@ public class PrebuiltTransformsTest {
 
     Metadata metadata = new Metadata();
     metadata.add("author", "J.  D.  Salinger");
-    metadata.add("author", "  J.  K.  Rowlings  ");
+    metadata.add("author", "  J.  K.  Rowling  ");
     Map<String, String> params = new HashMap<String, String>();
     params.put("colour", "burnt  orange  ");
     transform.transform(metadata, params);


### PR DESCRIPTION
The configurations for replace string, pattern, and replacement args
are intentionaly not trimmed, allowing patterns, etc, to have leading
and trailing whitespace. Unfortunately PrebuiltTranform.replaceInParams()
would trim the original values read (and perform emptyToNull conversion).
This could cause the value to not match the string or pattern and failed
on empty values.

This change causes replaceInParams() to use the unmodified original values
for the parameters. It also adds more extensive tests for whole value
replacements; empty Strings for string, pattern, replacement, and values;
and untrimmed Strings for string, pattern, replacement, and values.